### PR TITLE
feat: num/caps lock on start

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -14,6 +14,12 @@
 # Each entry is passed to sh -c, so full shell syntax works (pipes, &&, env vars).
 # autostart = []
 
+# Disable numlock on startup.
+# numlock = false
+
+# Enable virtual keyboard protocol.
+# virtual_keyboard = true
+
 # Environment variables set before any clients launch.
 # Child processes (autostart, exec bindings) inherit these.
 # These override the compositor's built-in toolkit defaults

--- a/config.example.toml
+++ b/config.example.toml
@@ -31,9 +31,8 @@
 # repeat_rate = 25           # keys/sec
 # repeat_delay = 200         # ms before repeat starts
 # layout_independent = true  # match bindings by physical key position across layouts
-# num_lock = false           # Disable num lock on startup.
-# caps_lock = true           # Enable caps lock on startup.
-# virtual_keyboard = true    # Enable virtual keyboard protocol.
+# num_lock = true            # num lock state on startup
+# caps_lock = false          # caps lock state on startup
 
 [input.trackpad]
 # tap_to_click = true         # enable tap-to-click

--- a/config.example.toml
+++ b/config.example.toml
@@ -31,7 +31,8 @@
 # repeat_rate = 25           # keys/sec
 # repeat_delay = 200         # ms before repeat starts
 # layout_independent = true  # match bindings by physical key position across layouts
-# numlock = false            # Disable numlock on startup.
+# num_lock = false           # Disable num lock on startup.
+# caps_lock = true           # Enable caps lock on startup.
 # virtual_keyboard = true    # Enable virtual keyboard protocol.
 
 [input.trackpad]

--- a/config.example.toml
+++ b/config.example.toml
@@ -14,12 +14,6 @@
 # Each entry is passed to sh -c, so full shell syntax works (pipes, &&, env vars).
 # autostart = []
 
-# Disable numlock on startup.
-# numlock = false
-
-# Enable virtual keyboard protocol.
-# virtual_keyboard = true
-
 # Environment variables set before any clients launch.
 # Child processes (autostart, exec bindings) inherit these.
 # These override the compositor's built-in toolkit defaults
@@ -37,6 +31,8 @@
 # repeat_rate = 25           # keys/sec
 # repeat_delay = 200         # ms before repeat starts
 # layout_independent = true  # match bindings by physical key position across layouts
+# numlock = false            # Disable numlock on startup.
+# virtual_keyboard = true    # Enable virtual keyboard protocol.
 
 [input.trackpad]
 # tap_to_click = true         # enable tap-to-click

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -90,7 +90,6 @@ pub struct Config {
     pub gestures: ContextBindings<GestureBinding, GestureConfigEntry>,
     pub num_lock: bool,
     pub caps_lock: bool,
-    pub virtual_keyboard: bool,
 }
 
 impl Config {
@@ -484,7 +483,6 @@ impl Config {
             gestures: gesture_bindings,
             num_lock: raw.input.keyboard.num_lock.unwrap_or(true),
             caps_lock: raw.input.keyboard.caps_lock.unwrap_or(false),
-            virtual_keyboard: raw.input.keyboard.virtual_keyboard.unwrap_or(false),
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -483,7 +483,7 @@ impl Config {
             mouse: mouse_bindings,
             gestures: gesture_bindings,
             num_lock: raw.input.keyboard.num_lock.unwrap_or(true),
-            caps_lock: raw.input.keyboard.caps_lock.unwrap_or(true),
+            caps_lock: raw.input.keyboard.caps_lock.unwrap_or(false),
             virtual_keyboard: raw.input.keyboard.virtual_keyboard.unwrap_or(false),
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -481,8 +481,8 @@ impl Config {
             bindings,
             mouse: mouse_bindings,
             gestures: gesture_bindings,
-            virtual_keyboard: raw.virtual_keyboard.unwrap_or(false),
-            numlock: raw.numlock.unwrap_or(true),
+            virtual_keyboard: raw.input.keyboard.virtual_keyboard.unwrap_or(false),
+            numlock: raw.input.keyboard.numlock.unwrap_or(true),
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -88,8 +88,9 @@ pub struct Config {
     bindings: HashMap<KeyCombo, Action>,
     pub mouse: ContextBindings<MouseBinding, MouseAction>,
     pub gestures: ContextBindings<GestureBinding, GestureConfigEntry>,
+    pub num_lock: bool,
+    pub caps_lock: bool,
     pub virtual_keyboard: bool,
-    pub numlock: bool,
 }
 
 impl Config {
@@ -481,8 +482,9 @@ impl Config {
             bindings,
             mouse: mouse_bindings,
             gestures: gesture_bindings,
+            num_lock: raw.input.keyboard.num_lock.unwrap_or(true),
+            caps_lock: raw.input.keyboard.caps_lock.unwrap_or(true),
             virtual_keyboard: raw.input.keyboard.virtual_keyboard.unwrap_or(false),
-            numlock: raw.input.keyboard.numlock.unwrap_or(true),
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -88,6 +88,8 @@ pub struct Config {
     bindings: HashMap<KeyCombo, Action>,
     pub mouse: ContextBindings<MouseBinding, MouseAction>,
     pub gestures: ContextBindings<GestureBinding, GestureConfigEntry>,
+    pub virtual_keyboard: bool,
+    pub numlock: bool,
 }
 
 impl Config {
@@ -479,6 +481,8 @@ impl Config {
             bindings,
             mouse: mouse_bindings,
             gestures: gesture_bindings,
+            virtual_keyboard: raw.virtual_keyboard.unwrap_or(false),
+            numlock: raw.numlock.unwrap_or(true),
         }
     }
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -74,7 +74,6 @@ pub(super) struct KeyboardConfig {
     pub layout_independent: Option<bool>,
     pub num_lock: Option<bool>,
     pub caps_lock: Option<bool>,
-    pub virtual_keyboard: Option<bool>,
 }
 
 #[derive(Deserialize, Default)]

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -25,6 +25,8 @@ pub(super) struct ConfigFile {
     pub xwayland: XWaylandConfig,
     pub window_rules: Option<Vec<WindowRuleFile>>,
     pub outputs: Option<Vec<OutputRuleFile>>,
+    pub virtual_keyboard: Option<bool>,
+    pub numlock: Option<bool>,
 }
 
 #[derive(Deserialize, Default)]

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -72,7 +72,8 @@ pub(super) struct KeyboardConfig {
     pub options: Option<String>,
     pub model: Option<String>,
     pub layout_independent: Option<bool>,
-    pub numlock: Option<bool>,
+    pub num_lock: Option<bool>,
+    pub caps_lock: Option<bool>,
     pub virtual_keyboard: Option<bool>,
 }
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -25,8 +25,6 @@ pub(super) struct ConfigFile {
     pub xwayland: XWaylandConfig,
     pub window_rules: Option<Vec<WindowRuleFile>>,
     pub outputs: Option<Vec<OutputRuleFile>>,
-    pub virtual_keyboard: Option<bool>,
-    pub numlock: Option<bool>,
 }
 
 #[derive(Deserialize, Default)]
@@ -74,6 +72,8 @@ pub(super) struct KeyboardConfig {
     pub options: Option<String>,
     pub model: Option<String>,
     pub layout_independent: Option<bool>,
+    pub numlock: Option<bool>,
+    pub virtual_keyboard: Option<bool>,
 }
 
 #[derive(Deserialize, Default)]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -306,8 +306,8 @@ impl IdleInhibitHandler for DriftWm {
 
 delegate_idle_inhibit!(DriftWm);
 
+use smithay::delegate_idle_notify;
 use smithay::wayland::idle_notify::{IdleNotifierHandler, IdleNotifierState};
-use smithay::{delegate_idle_notify, delegate_virtual_keyboard_manager};
 
 impl IdleNotifierHandler for DriftWm {
     fn idle_notifier_state(&mut self) -> &mut IdleNotifierState<Self> {
@@ -650,5 +650,3 @@ impl SessionLockHandler for DriftWm {
 }
 
 delegate_session_lock!(DriftWm);
-
-delegate_virtual_keyboard_manager!(DriftWm);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -67,7 +67,8 @@ impl SeatHandler for DriftWm {
         // Wait but let client surface cursors through (they take priority).
         if self.cursor.exec_cursor_deadline.is_some()
             && self
-                .cursor.exec_cursor_show_at
+                .cursor
+                .exec_cursor_show_at
                 .is_none_or(|t| std::time::Instant::now() >= t)
             && matches!(&image, CursorImageStatus::Named(icon) if *icon == CursorIcon::Default)
         {
@@ -257,17 +258,18 @@ impl PointerConstraintsHandler for DriftWm {
     ) {
         use smithay::wayland::pointer_constraints::with_pointer_constraint;
 
-        let is_active = with_pointer_constraint(surface, pointer, |c| {
-            c.is_some_and(|c| c.is_active())
-        });
+        let is_active =
+            with_pointer_constraint(surface, pointer, |c| c.is_some_and(|c| c.is_active()));
         if !is_active {
             return;
         }
 
         // location is surface-local. Find the surface's canvas origin to convert.
-        let window = self.space.elements().find(|w| {
-            w.wl_surface().as_deref() == Some(surface)
-        }).cloned();
+        let window = self
+            .space
+            .elements()
+            .find(|w| w.wl_surface().as_deref() == Some(surface))
+            .cloned();
         if let Some(window) = window
             && let Some(loc) = self.space.element_location(&window)
         {
@@ -304,8 +306,8 @@ impl IdleInhibitHandler for DriftWm {
 
 delegate_idle_inhibit!(DriftWm);
 
-use smithay::delegate_idle_notify;
 use smithay::wayland::idle_notify::{IdleNotifierHandler, IdleNotifierState};
+use smithay::{delegate_idle_notify, delegate_virtual_keyboard_manager};
 
 impl IdleNotifierHandler for DriftWm {
     fn idle_notifier_state(&mut self) -> &mut IdleNotifierState<Self> {
@@ -648,3 +650,5 @@ impl SessionLockHandler for DriftWm {
 }
 
 delegate_session_lock!(DriftWm);
+
+delegate_virtual_keyboard_manager!(DriftWm);

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -31,7 +31,6 @@ use smithay::{
         selection::data_device::DataDeviceState,
         shell::xdg::XdgShellState,
         shm::ShmState,
-        virtual_keyboard::VirtualKeyboardManagerState,
     },
 };
 use std::collections::{HashMap, HashSet};
@@ -526,8 +525,6 @@ impl DriftWm {
             ..Default::default()
         });
         seat.add_pointer();
-
-        VirtualKeyboardManagerState::new::<Self, _>(&dh, |_client| Config::load().virtual_keyboard);
 
         let autostart = config.autostart.clone();
         Self {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -418,9 +418,6 @@ pub struct DriftWm {
         Instant,
         smithay::reexports::wayland_server::backend::ObjectId,
     )>,
-
-    // -- global: virtual keyboard --
-    pub virtual_keyboard_state: Option<VirtualKeyboardManagerState>,
 }
 
 /// Per-client state stored by wayland-server for each connected client.
@@ -530,15 +527,7 @@ impl DriftWm {
         });
         seat.add_pointer();
 
-        let vk = config.virtual_keyboard.clone();
-        let virtual_keyboard_state = if vk {
-            Some(VirtualKeyboardManagerState::new::<Self, _>(
-                &dh,
-                move |_client| vk,
-            ))
-        } else {
-            None
-        };
+        VirtualKeyboardManagerState::new::<Self, _>(&dh, |_client| Config::load().virtual_keyboard);
 
         let autostart = config.autostart.clone();
         Self {
@@ -624,7 +613,6 @@ impl DriftWm {
             x11_display: None,
             xwayland_client: None,
             last_titlebar_click: None,
-            virtual_keyboard_state,
         }
     }
 
@@ -1476,18 +1464,6 @@ impl DriftWm {
                 tracing::info!("Config reload: env unset {key}");
                 unsafe { std::env::remove_var(key) };
             }
-        }
-
-        if new_config.virtual_keyboard != self.config.virtual_keyboard {
-            let nvk = new_config.virtual_keyboard.clone();
-            self.virtual_keyboard_state = if nvk {
-                Some(VirtualKeyboardManagerState::new::<Self, _>(
-                    &self.display_handle,
-                    move |_client| nvk,
-                ))
-            } else {
-                None
-            };
         }
 
         self.config = new_config;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -9,7 +9,10 @@ pub use render_cache::RenderCache;
 
 use smithay::{
     desktop::{PopupManager, Space, Window},
-    input::{Seat, SeatState, keyboard::XkbConfig},
+    input::{
+        Seat, SeatState,
+        keyboard::{ModifiersState, XkbConfig},
+    },
     output::Output,
     reexports::{
         calloop::{LoopHandle, LoopSignal},
@@ -21,13 +24,14 @@ use smithay::{
         },
     },
     utils::{Logical, Point, Rectangle, Size},
-    wayland::output::OutputManagerState,
     wayland::{
         compositor::{CompositorClientState, CompositorState},
         cursor_shape::CursorShapeManagerState,
+        output::OutputManagerState,
         selection::data_device::DataDeviceState,
         shell::xdg::XdgShellState,
         shm::ShmState,
+        virtual_keyboard::VirtualKeyboardManagerState,
     },
 };
 use std::collections::{HashMap, HashSet};
@@ -379,7 +383,6 @@ pub struct DriftWm {
     pub redraws_needed: HashSet<crtc::Handle>,
     pub frames_pending: HashSet<crtc::Handle>,
 
-
     // -- global: config hot-reload --
     pub config_file_mtime: Option<std::time::SystemTime>,
 
@@ -415,6 +418,9 @@ pub struct DriftWm {
         Instant,
         smithay::reexports::wayland_server::backend::ObjectId,
     )>,
+
+    // -- global: virtual keyboard --
+    pub virtual_keyboard_state: VirtualKeyboardManagerState,
 }
 
 /// Per-client state stored by wayland-server for each connected client.
@@ -514,9 +520,19 @@ impl DriftWm {
             model: &kb.model,
             ..Default::default()
         };
-        seat.add_keyboard(xkb, config.repeat_delay, config.repeat_rate)
+        let keyboard = seat
+            .add_keyboard(xkb, config.repeat_delay, config.repeat_rate)
             .expect("Failed to add keyboard");
+        keyboard.set_modifier_state(ModifiersState {
+            num_lock: config.numlock,
+            ..Default::default()
+        });
         seat.add_pointer();
+
+        let vk = config.virtual_keyboard.clone();
+        let virtual_keyboard_state =
+            VirtualKeyboardManagerState::new::<Self, _>(&dh, move |_client| vk);
+
         let autostart = config.autostart.clone();
         Self {
             start_time: Instant::now(),
@@ -601,6 +617,7 @@ impl DriftWm {
             x11_display: None,
             xwayland_client: None,
             last_titlebar_click: None,
+            virtual_keyboard_state,
         }
     }
 
@@ -1158,9 +1175,10 @@ impl DriftWm {
         loop {
             let dominated = self.space.elements().any(|w| {
                 w != skip
-                    && self.space.element_location(w).is_some_and(|loc| {
-                        (loc.x - pos.0).abs() <= 2 && (loc.y - pos.1).abs() <= 2
-                    })
+                    && self
+                        .space
+                        .element_location(w)
+                        .is_some_and(|loc| (loc.x - pos.0).abs() <= 2 && (loc.y - pos.1).abs() <= 2)
             });
             if !dominated {
                 break pos;
@@ -1453,6 +1471,14 @@ impl DriftWm {
             }
         }
 
+        if new_config.virtual_keyboard != self.config.virtual_keyboard {
+            let nvk = new_config.virtual_keyboard.clone();
+            self.virtual_keyboard_state =
+                VirtualKeyboardManagerState::new::<Self, _>(&self.display_handle, move |_client| {
+                    nvk
+                });
+        }
+
         self.config = new_config;
         self.mark_all_dirty();
         tracing::info!("Config reloaded");
@@ -1471,10 +1497,18 @@ impl DriftWm {
         };
         let mut others = Vec::new();
         for w in self.space.elements() {
-            let Some(surface) = w.wl_surface() else { continue };
-            if *surface == *exclude { continue }
-            if driftwm::config::applied_rule(&surface).is_some_and(|r| r.widget) { continue }
-            let Some(loc) = self.space.element_location(w) else { continue };
+            let Some(surface) = w.wl_surface() else {
+                continue;
+            };
+            if *surface == *exclude {
+                continue;
+            }
+            if driftwm::config::applied_rule(&surface).is_some_and(|r| r.widget) {
+                continue;
+            }
+            let Some(loc) = self.space.element_location(w) else {
+                continue;
+            };
             let size = w.geometry().size;
             let bar = if self.decorations.contains_key(&surface.id()) {
                 driftwm::config::DecorationConfig::TITLE_BAR_HEIGHT

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -11,7 +11,7 @@ use smithay::{
     desktop::{PopupManager, Space, Window},
     input::{
         Seat, SeatState,
-        keyboard::{ModifiersState, XkbConfig},
+        keyboard::{ModifiersState, SerializedMods, XkbConfig},
     },
     output::Output,
     reexports::{
@@ -524,7 +524,8 @@ impl DriftWm {
             .add_keyboard(xkb, config.repeat_delay, config.repeat_rate)
             .expect("Failed to add keyboard");
         keyboard.set_modifier_state(ModifiersState {
-            num_lock: config.numlock,
+            num_lock: config.num_lock,
+            caps_lock: config.caps_lock,
             ..Default::default()
         });
         seat.add_pointer();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -11,7 +11,7 @@ use smithay::{
     desktop::{PopupManager, Space, Window},
     input::{
         Seat, SeatState,
-        keyboard::{ModifiersState, SerializedMods, XkbConfig},
+        keyboard::{ModifiersState, XkbConfig},
     },
     output::Output,
     reexports::{
@@ -420,7 +420,7 @@ pub struct DriftWm {
     )>,
 
     // -- global: virtual keyboard --
-    pub virtual_keyboard_state: VirtualKeyboardManagerState,
+    pub virtual_keyboard_state: Option<VirtualKeyboardManagerState>,
 }
 
 /// Per-client state stored by wayland-server for each connected client.
@@ -531,8 +531,14 @@ impl DriftWm {
         seat.add_pointer();
 
         let vk = config.virtual_keyboard.clone();
-        let virtual_keyboard_state =
-            VirtualKeyboardManagerState::new::<Self, _>(&dh, move |_client| vk);
+        let virtual_keyboard_state = if vk {
+            Some(VirtualKeyboardManagerState::new::<Self, _>(
+                &dh,
+                move |_client| vk,
+            ))
+        } else {
+            None
+        };
 
         let autostart = config.autostart.clone();
         Self {
@@ -1474,10 +1480,14 @@ impl DriftWm {
 
         if new_config.virtual_keyboard != self.config.virtual_keyboard {
             let nvk = new_config.virtual_keyboard.clone();
-            self.virtual_keyboard_state =
-                VirtualKeyboardManagerState::new::<Self, _>(&self.display_handle, move |_client| {
-                    nvk
-                });
+            self.virtual_keyboard_state = if nvk {
+                Some(VirtualKeyboardManagerState::new::<Self, _>(
+                    &self.display_handle,
+                    move |_client| nvk,
+                ))
+            } else {
+                None
+            };
         }
 
         self.config = new_config;


### PR DESCRIPTION
~~This PR adds Wayland's virtual keyboard protocol. It's off by default, and no client filter has been implemented. It can be toggled on/off live on config reloads.~~ It also adds support for turning numlock on by default.

```toml
[input.keyboard]
# num_lock = true            # num lock state on startup
# caps_lock = false          # caps lock state on startup
```

I'd like to also add scroll lock support, however, `ModifiersState` only has the other two.