### PR TITLE
Fix focus loss when destroying a standalone toplevel

### DIFF
--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -193,7 +193,16 @@ impl XdgShellHandler for DriftWm {
                 .is_some_and(|f| f.0 == wl_surface)
             {
                 let serial = smithay::utils::SERIAL_COUNTER.next_serial();
-                keyboard.set_focus(self, parent_focus, serial);
+                // Standalone toplevels have no parent — fall back to the most
+                // recent previous window so focus does not vanish (important
+                // with focus_follows_mouse when the pointer is over empty canvas).
+                let fallback = parent_focus.or_else(|| {
+                    self.focus_history
+                        .iter()
+                        .find(|w| w != &window)
+                        .and_then(|w| w.wl_surface().map(|s| FocusTarget(s.into_owned())))
+                });
+                keyboard.set_focus(self, fallback, serial);
             }
             // If the destroyed window was fullscreen, restore viewport
             let fs_output = self.fullscreen.iter()


### PR DESCRIPTION
### Changes
In `toplevel_destroyed`, when the destroyed xdg-toplevel has no parent surface, fall back to the most recent previous window from `focus_history` instead of calling `set_focus(None)`.

### Purpose
With `focus_follows_mouse = true`, closing a standalone picker window (clipboard manager, launcher wrapped in a terminal, etc.) leaves keyboard focus empty until the pointer crosses another surface. The XWayland path already has this fallback; this brings xdg_shell in line.

Fixes #40