### PR TITLE
Add virtual keyboard protocol gated by security context

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -44,6 +44,8 @@ trackpad gestures. No workspaces, no tiling — just drift.
   - `xwayland-shell` — X11 app support via Xwayland
   - `ext-idle-notify` — idle detection (swayidle, hypridle)
   - `wp_single_pixel_buffer` — 1x1 solid color buffers (GTK4 backgrounds/separators)
+  - `zwp_virtual_keyboard_v1` — synthesized key events (wtype, clipboard auto-paste). Gated behind `wp_security_context_v1`.
+  - `wp_security_context_v1` — sandbox attribution for clients; restricts access to privileged protocols
 
 ## Core concept: infinite canvas
 
@@ -779,5 +781,5 @@ requiring real hardware (udev/TTY). Milestones 1–8 work entirely in winit.
 14. **XWayland** — X11 app support via Xwayland, WindowExt trait for polymorphism _(done)_
 15. **Blur** — multi-pass Kawase blur, per-window via window rules, opacity support _(done)_
 16. **Pinned-to-screen** — `pinned_to_screen` window rule: window stays always on top, position in viewport (screen) coordinates instead of canvas coordinates
-17. **Text input / IME** — `text-input` v3, `input-method` v2, `virtual-keyboard` v1. Required for CJK input (Chinese/Japanese/Korean) and on-screen keyboards. Input method popup positioning on the canvas.
+17. **Text input / IME** — `text-input` v3, `input-method` v2, `virtual-keyboard` v1 _(done, gated by `wp_security_context_v1`)_. Text-input and input-method still required for CJK input (Chinese/Japanese/Korean) and on-screen keyboards. Input method popup positioning on the canvas.
 18. **Input polish** — NumLock-on-startup config option (`[input.keyboard] numlock = true`), virtual pointer protocol (`zwp-virtual-pointer-v1`) for remote desktop tools (wayvnc, GNOME Remote Desktop)

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -13,7 +13,8 @@ use smithay::{
     delegate_fractional_scale, delegate_idle_inhibit, delegate_keyboard_shortcuts_inhibit,
     delegate_output, delegate_pointer_constraints, delegate_pointer_gestures,
     delegate_presentation, delegate_primary_selection, delegate_relative_pointer, delegate_seat,
-    delegate_single_pixel_buffer, delegate_viewporter, delegate_xdg_activation,
+    delegate_security_context, delegate_single_pixel_buffer, delegate_viewporter,
+    delegate_virtual_keyboard_manager, delegate_xdg_activation,
     input::{
         Seat, SeatHandler, SeatState, keyboard,
         dnd::{self, DnDGrab},
@@ -33,6 +34,9 @@ use smithay::{
         keyboard_shortcuts_inhibit::{KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitor},
         output::OutputHandler,
         pointer_constraints::PointerConstraintsHandler,
+        security_context::{
+            SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
+        },
         selection::{
             SelectionHandler, SelectionSource, SelectionTarget,
             data_device::{
@@ -340,6 +344,32 @@ impl KeyboardShortcutsInhibitHandler for DriftWm {
 }
 
 delegate_keyboard_shortcuts_inhibit!(DriftWm);
+
+impl SecurityContextHandler for DriftWm {
+    fn context_created(
+        &mut self,
+        source: SecurityContextListenerSource,
+        context: SecurityContext,
+    ) {
+        let result = self
+            .loop_handle
+            .insert_source(source, move |client, _, state| {
+                tracing::debug!("inserting restricted client from security context: {context:?}");
+                let data = std::sync::Arc::new(crate::state::ClientState {
+                    compositor_state: Default::default(),
+                    restricted: true,
+                });
+                if let Err(err) = state.display_handle.insert_client(client, data) {
+                    tracing::warn!("failed to insert restricted client: {err}");
+                }
+            });
+        if let Err(err) = result {
+            tracing::warn!("failed to register security context listener: {err}");
+        }
+    }
+}
+delegate_security_context!(DriftWm);
+delegate_virtual_keyboard_manager!(DriftWm);
 
 impl IdleInhibitHandler for DriftWm {
     fn inhibit(&mut self, _surface: WlSurface) {}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -50,8 +50,10 @@ use smithay::wayland::pointer_constraints::PointerConstraintsState;
 use smithay::wayland::pointer_gestures::PointerGesturesState;
 use smithay::wayland::presentation::PresentationState;
 use smithay::wayland::relative_pointer::RelativePointerManagerState;
+use smithay::wayland::security_context::SecurityContextState;
 use smithay::wayland::selection::primary_selection::PrimarySelectionState;
 use smithay::wayland::selection::wlr_data_control::DataControlState;
+use smithay::wayland::virtual_keyboard::VirtualKeyboardManagerState;
 use smithay::wayland::session_lock::{LockSurface, SessionLockManagerState, SessionLocker};
 use smithay::wayland::shell::wlr_layer::WlrLayerShellState;
 use smithay::wayland::shell::xdg::decoration::XdgDecorationState;
@@ -312,6 +314,10 @@ pub struct DriftWm {
     #[allow(dead_code)]
     pub keyboard_shortcuts_inhibit_state: KeyboardShortcutsInhibitState,
     #[allow(dead_code)]
+    pub virtual_keyboard_state: VirtualKeyboardManagerState,
+    #[allow(dead_code)]
+    pub security_context_state: SecurityContextState,
+    #[allow(dead_code)]
     pub idle_inhibit_state: IdleInhibitManagerState,
     pub idle_notifier_state: IdleNotifierState<DriftWm>,
     #[allow(dead_code)]
@@ -424,6 +430,9 @@ pub struct DriftWm {
 #[derive(Default)]
 pub struct ClientState {
     pub compositor_state: CompositorClientState,
+    /// Clients connected via a security-context listener are restricted from
+    /// privileged protocols (virtual keyboard, etc.). See SecurityContextHandler.
+    pub restricted: bool,
 }
 
 impl ClientData for ClientState {
@@ -462,6 +471,22 @@ impl DriftWm {
         let relative_pointer_state = RelativePointerManagerState::new::<Self>(&dh);
         let _pointer_gestures_state = PointerGesturesState::new::<Self>(&dh);
         let keyboard_shortcuts_inhibit_state = KeyboardShortcutsInhibitState::new::<Self>(&dh);
+        // Restricted clients (those connecting through a security-context listener)
+        // are denied access to privileged protocols such as virtual keyboard.
+        // Clients without a ClientState (e.g. XWayland's internal client, whose
+        // setup callback doesn't attach one) are treated as unrestricted since
+        // they are spawned by the compositor itself.
+        fn client_is_unrestricted(
+            client: &smithay::reexports::wayland_server::Client,
+        ) -> bool {
+            client
+                .get_data::<ClientState>()
+                .map_or(true, |d| !d.restricted)
+        }
+        let security_context_state =
+            SecurityContextState::new::<Self, _>(&dh, client_is_unrestricted);
+        let virtual_keyboard_state =
+            VirtualKeyboardManagerState::new::<Self, _>(&dh, client_is_unrestricted);
         let idle_inhibit_state = IdleInhibitManagerState::new::<Self>(&dh);
         let idle_notifier_state = IdleNotifierState::new(&dh, loop_handle.clone());
         let presentation_state = PresentationState::new::<Self>(&dh, 1); // CLOCK_MONOTONIC
@@ -559,6 +584,8 @@ impl DriftWm {
             pointer_constraints_state,
             relative_pointer_state,
             keyboard_shortcuts_inhibit_state,
+            virtual_keyboard_state,
+            security_context_state,
             idle_inhibit_state,
             idle_notifier_state,
             presentation_state,


### PR DESCRIPTION
### Changes
Adds `zwp-virtual-keyboard-v1` so Wayland-native clients can synthesize key events. Gated behind `wp-security-context-v1` following the niri pattern — clients connecting through a security context listener are marked `restricted: true` in `ClientState` and the filter denies them access to virtual keyboard.

- `src/state/mod.rs`: new `restricted` field in `ClientState`; `SecurityContextState` and `VirtualKeyboardManagerState` initialized with a shared `client_is_unrestricted` filter.
- `src/handlers/mod.rs`: `SecurityContextHandler` impl that inserts restricted clients from the listener source; delegates added.
- `docs/DESIGN.md`: protocols listed under implemented; Milestone 17 marked done for virtual-keyboard.

### Purpose
Enables tools like `wtype` and on-screen keyboards without the ydotool/`/dev/uinput` workaround. Required for clipboard auto-paste workflows and accessibility input methods.

### Testing
- `cargo build` / `cargo clippy -D warnings` / `cargo test` all clean.
- Manual: with the patched compositor running, `wtype "hola mundo"` injects the string into the focused terminal. Without the patch, `wtype` fails with *"Compositor does not support the virtual keyboard protocol"*.

### Notes
Clients without a `ClientState` (the compositor's own XWayland client, whose `XWayland::spawn` setup callback currently doesn't attach one) are treated as unrestricted. Happy to explicitly attach `ClientState` in the XWayland spawn path if you prefer — felt out of scope for this PR.

Closes #43