### PR TITLE
extras/wallpapers: add fast_smoke, acid_lava, dense_clouds shaders

### DIFF
--- a/extras/wallpapers/acid_lava.glsl
+++ b/extras/wallpapers/acid_lava.glsl
@@ -1,0 +1,60 @@
+// Acid lava — low-saturation ember veins over dark crust
+precision highp float;
+
+varying vec2 v_coords;
+uniform vec2 size;
+uniform float alpha;
+uniform vec2 u_camera;
+uniform float u_time;
+
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+float noise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(
+        mix(hash(i),                  hash(i + vec2(1.0, 0.0)), f.x),
+        mix(hash(i + vec2(0.0, 1.0)), hash(i + vec2(1.0, 1.0)), f.x),
+        f.y
+    );
+}
+
+float fbm(vec2 p) {
+    float sum = 0.0, amp = 0.5;
+    mat2 rot = mat2(0.80, 0.60, -0.60, 0.80);
+    for (int i = 0; i < 5; i++) {
+        sum += amp * noise(p);
+        p = rot * p * 2.1;
+        amp *= 0.5;
+    }
+    return sum;
+}
+
+void main() {
+    vec2 uv = (v_coords * size + u_camera) / 260.0;
+    vec2 drift = vec2(u_time * 0.07, -u_time * 0.04);
+
+    float base   = fbm(uv * 1.1 + drift);
+    float detail = fbm(uv * 2.2 - drift * 1.2 + vec2(base));
+    // Higher frequency layer warped by base+detail to form crack-like veins
+    float veins  = fbm(uv * 3.0 + vec2(detail, base) * 1.8 - vec2(0.0, u_time * 0.03));
+
+    float molten = smoothstep(0.42, 0.68, base + detail * 0.35);
+    // Thin bright lines at the 0.52 contour of the vein noise
+    float cracks = 1.0 - smoothstep(0.08, 0.18, abs(veins - 0.52));
+    float ember  = molten * (0.60 + cracks * 0.65);
+
+    vec3 crust    = vec3(0.080, 0.050, 0.045);
+    vec3 rock     = vec3(0.170, 0.095, 0.070);
+    vec3 emberCol = vec3(0.640, 0.260, 0.120);
+    vec3 hot      = vec3(0.920, 0.560, 0.220);
+
+    vec3 col = mix(crust, rock, molten * 0.45);
+    col += emberCol * ember * 0.65;
+    col += hot * pow(ember, 2.2) * 0.30;
+
+    gl_FragColor = vec4(col, 1.0) * alpha;
+}

--- a/extras/wallpapers/dense_clouds.glsl
+++ b/extras/wallpapers/dense_clouds.glsl
@@ -1,0 +1,76 @@
+// Dense clouds — stormy sky with gold sun backlighting
+precision highp float;
+
+varying vec2 v_coords;
+uniform vec2 size;
+uniform float alpha;
+uniform vec2 u_camera;
+uniform float u_time;
+
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+float noise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(
+        mix(hash(i),                  hash(i + vec2(1.0, 0.0)), f.x),
+        mix(hash(i + vec2(0.0, 1.0)), hash(i + vec2(1.0, 1.0)), f.x),
+        f.y
+    );
+}
+
+float fbm(vec2 p) {
+    float sum = 0.0, amp = 0.5;
+    mat2 rot = mat2(0.8, 0.6, -0.6, 0.8);
+    for (int i = 0; i < 6; i++) {
+        sum += amp * noise(p);
+        p = rot * p * 2.0;
+        amp *= 0.5;
+    }
+    return sum;
+}
+
+void main() {
+    vec2 uv = (v_coords * size + u_camera) / 380.0;
+
+    // Slow wind drift
+    uv.x += u_time * 0.018;
+    uv.y += u_time * 0.007;
+
+    // Domain warp for organic billowing shapes
+    float warpX = fbm(uv * 0.7 + vec2(0.0, u_time * 0.012));
+    float warpY = fbm(uv * 0.8 + vec2(u_time * 0.010, 5.3));
+    vec2 warped = uv + vec2(warpX - 0.5, warpY - 0.5) * 3.0;
+
+    float cloud  = fbm(warped);
+    float detail = fbm(warped * 2.5 + vec2(4.1, 2.3));
+    float micro  = fbm(warped * 5.0 + vec2(1.7, 6.8));
+
+    // Weighted sum of three frequency bands; micro adds fine edge detail
+    float density = clamp(
+        smoothstep(0.30, 0.68, cloud)  * 0.72 +
+        smoothstep(0.38, 0.74, detail) * 0.22 +
+        smoothstep(0.46, 0.80, micro)  * 0.10,
+        0.0, 1.0
+    );
+
+    // Sun backlighting: glow is strongest on dense cloud edges
+    float sunLight = fbm(warped * 1.2 + vec2(0.0, 1.5));
+    float sunGlow  = smoothstep(0.55, 0.85, sunLight) * density * 0.55;
+
+    vec3 sky        = vec3(0.157, 0.220, 0.392);
+    vec3 stormGray  = vec3(0.157, 0.165, 0.235);
+    vec3 midCloud   = vec3(0.322, 0.333, 0.455);
+    vec3 brightEdge = vec3(0.639, 0.655, 0.745);
+    vec3 sunColor   = vec3(0.980, 0.847, 0.600);
+
+    vec3 col = mix(sky, stormGray, density);
+    col = mix(col, midCloud,   smoothstep(0.28, 0.62, density));
+    col = mix(col, brightEdge, smoothstep(0.58, 0.84, density) * 0.35);
+    col = mix(col, sunColor,   sunGlow * 0.50);
+
+    gl_FragColor = vec4(col, 1.0) * alpha;
+}

--- a/extras/wallpapers/fast_smoke.glsl
+++ b/extras/wallpapers/fast_smoke.glsl
@@ -1,0 +1,75 @@
+// Fast smoke — animated turbulent Catppuccin Mocha plumes
+precision highp float;
+
+varying vec2 v_coords;
+uniform vec2 size;
+uniform float alpha;
+uniform vec2 u_camera;
+uniform float u_time;
+
+// Single-component hash: avoids the second dot product since we never need .y
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+float noise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(
+        mix(hash(i),                  hash(i + vec2(1.0, 0.0)), f.x),
+        mix(hash(i + vec2(0.0, 1.0)), hash(i + vec2(1.0, 1.0)), f.x),
+        f.y
+    );
+}
+
+float fbm(vec2 p) {
+    float sum = 0.0, amp = 0.5;
+    mat2 rot = mat2(0.8, 0.6, -0.6, 0.8);
+    for (int i = 0; i < 5; i++) {
+        sum += amp * noise(p);
+        p = rot * p * 2.1;
+        amp *= 0.48;
+    }
+    return sum;
+}
+
+void main() {
+    vec2 uv = (v_coords * size + u_camera) / 280.0;
+    float t = u_time * 0.32;
+
+    // Upward rise with lateral turbulence drift
+    uv.y -= t * 0.85;
+    float driftX = fbm(vec2(uv.y * 1.5, t * 1.2)) - 0.5;
+    float driftY = fbm(vec2(uv.x * 1.3, t * 1.0)) - 0.5;
+    uv.x += driftX * 0.28;
+    uv.y += driftY * 0.15;
+
+    float warp1 = fbm(uv * 1.6 + vec2( t * 0.50, -t * 0.42));
+    float warp2 = fbm(uv * 2.0 - vec2( t * 0.45,  t * 0.38));
+
+    // Triple-cascade domain warp for chaotic, non-repeating plumes
+    vec2 q = vec2(
+        fbm(uv + vec2(warp1 * 0.4, warp2 * 0.35)),
+        fbm(uv + vec2(5.2, 1.3) + t * 0.15)
+    );
+    vec2 r = vec2(
+        fbm(uv + 5.0 * q + vec2(1.7, 9.2) + t * 0.35),
+        fbm(uv + 5.0 * q + vec2(8.3, 2.8) - t * 0.28)
+    );
+    float smoke = fbm(uv + 5.5 * r + t * 0.18);
+
+    // Catppuccin Mocha grayscale ramp: crust → mantle → surface → overlay → subtext
+    vec3 crust   = vec3(0.067, 0.067, 0.106);
+    vec3 mantle  = vec3(0.118, 0.118, 0.180);
+    vec3 surface = vec3(0.192, 0.196, 0.267);
+    vec3 overlay = vec3(0.364, 0.380, 0.502);
+    vec3 subtext = vec3(0.561, 0.576, 0.671);
+
+    vec3 col = mix(crust,   mantle,  smoothstep(0.25, 0.45, smoke));
+    col = mix(col, surface,  smoothstep(0.40, 0.60, smoke));
+    col = mix(col, overlay,  smoothstep(0.56, 0.74, smoke));
+    col = mix(col, subtext,  smoothstep(0.68, 0.88, smoke) * 0.55);
+
+    gl_FragColor = vec4(col, 1.0) * alpha;
+}


### PR DESCRIPTION
## New wallpaper shaders

Three new animated GLSL wallpapers for `extras/wallpapers/`:

### fast_smoke
Turbulent Catppuccin Mocha plumes with upward rise and lateral drift. Uses a triple-cascade domain warp (q → r → smoke) for chaotic, non-repeating patterns.

### acid_lava
Dark crust with glowing ember veins. High-frequency FBM crack noise thresholded at the 0.52 contour produces sharp lava vein lines; a power-law ember term gives the hot-glow feel.

### dense_clouds
6-octave FBM storm sky with slow wind drift and gold sun backlighting. Three frequency bands (cloud / detail / micro) are weighted and clamped for density; a separate sunlight FBM pass drives the edge glow.

---

All three shaders:
- Use `precision highp float` (consistent with other extras shaders)
- Replace the two-component `hash2` with a single-dot `hash` since only one component was ever used — avoids the redundant second dot product
- English-only comments explaining non-obvious logic
- Visually identical to the originals