### PR TITLE
Up rust requirements to 1.88

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ in
 
 ### Build from source
 
-Requires Rust 1.85+ (edition 2024).
+Requires Rust 1.88+ (edition 2024).
 
 **Fedora:**
 


### PR DESCRIPTION
**Let chains** and **image@0.25.10** requires **rustc 1.88**

```
Downloaded 168 crates (22.1MiB) in 4.28s (largest was `linux-raw-sys` at 2.9MiB)
error: rustc 1.87.0 is not supported by the following package: image@0.25.10 requires rustc 1.88.0
Either upgrade rustc or select compatible dependency versions with`cargo update <name>@<current-ver> --precise <compatible-ver>`where `<compatible-ver>` is the latest version supporting rustc 1.87.0
```

After `cargo update image@0.25.10 --precise 0.25.5`:

```
Compiling driftwm v0.4.0 (/home/user/driftwm)
error[E0658]: `let` expressions in this position are unstable --> src/config/defaults.rs:699:8 |699 | if let Ok(term) = std::env::var("TERMINAL") | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable --> src/config/defaults.rs:719:8 |719 | if let Ok(launcher) = std::env::var("LAUNCHER") | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable --> src/config/toml.rs:275:8 |275 | if let Some(rest) = path.strip_prefix("~/") | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable --> src/config/toml.rs:276:12 |276 | && let Ok(home) = std::env::var("HOME") | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable --> src/protocols/output_management.rs:222:8 |222 | if let Some(idx) = state.current_mode_index | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable --> src/protocols/output_management.rs:223:12 |223 | && let Some(wl_mode) = wl_modes.get(idx) | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable --> src/snap.rs:202:12 |202 | if let Some(cd) = *cooldown | ^^^^^^^^^^^^^^^^^^^^^^^^ | = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable --> src/snap.rs:210:16 |210 | && let Some((snapped_pos, _)) = find_snap_candidate(natural_pos, p) | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable --> src/snap.rs:356:12 |356 | if let Some(cd) = *cooldown | ^^^^^^^^^^^^^^^^^^^^^^^^ | = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
error[E0658]: `let` expressions in this position are unstable --> src/snap.rs:363:16 |363 | && let Some((snapped_pos, _)) = find_edge_snap(natural_edge, p) | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ | = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
For more information about this error, try `rustc --explain 
E0658`.error: could not compile `driftwm` (lib) due to 10 previous errors
```
