### PR TITLE
fix: render drag-and-drop cursor icon

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -133,7 +133,7 @@ impl WaylandDndGrabHandler for DriftWm {
         serial: Serial,
         type_: dnd::GrabType,
     ) {
-        self.dnd_icon = icon.map(|s| smithay::reexports::wayland_server::Resource::clone(&s));
+        self.dnd_icon = icon;
         match type_ {
             dnd::GrabType::Pointer => {
                 let pointer = seat.get_pointer().unwrap();

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -133,9 +133,7 @@ impl WaylandDndGrabHandler for DriftWm {
         serial: Serial,
         type_: dnd::GrabType,
     ) {
-        if let Some(ref surface) = icon {
-            self.cursor.cursor_status = CursorImageStatus::Surface(surface.clone());
-        }
+        self.dnd_icon = icon.map(|s| smithay::reexports::wayland_server::Resource::clone(&s));
         match type_ {
             dnd::GrabType::Pointer => {
                 let pointer = seat.get_pointer().unwrap();
@@ -160,7 +158,7 @@ impl dnd::DndGrabHandler for DriftWm {
         _seat: Seat<Self>,
         _location: Point<f64, Logical>,
     ) {
-        self.cursor.cursor_status = CursorImageStatus::default_named();
+        self.dnd_icon = None;
     }
 }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -128,11 +128,14 @@ impl WaylandDndGrabHandler for DriftWm {
     fn dnd_requested<S: dnd::Source>(
         &mut self,
         source: S,
-        _icon: Option<WlSurface>,
+        icon: Option<WlSurface>,
         seat: Seat<Self>,
         serial: Serial,
         type_: dnd::GrabType,
     ) {
+        if let Some(ref surface) = icon {
+            self.cursor.cursor_status = CursorImageStatus::Surface(surface.clone());
+        }
         match type_ {
             dnd::GrabType::Pointer => {
                 let pointer = seat.get_pointer().unwrap();
@@ -149,7 +152,17 @@ impl WaylandDndGrabHandler for DriftWm {
         }
     }
 }
-impl dnd::DndGrabHandler for DriftWm {}
+impl dnd::DndGrabHandler for DriftWm {
+    fn dropped(
+        &mut self,
+        _target: Option<dnd::DndTarget<'_, Self>>,
+        _validated: bool,
+        _seat: Seat<Self>,
+        _location: Point<f64, Logical>,
+    ) {
+        self.cursor.cursor_status = CursorImageStatus::default_named();
+    }
+}
 
 delegate_data_device!(DriftWm);
 

--- a/src/render/cursor.rs
+++ b/src/render/cursor.rs
@@ -34,7 +34,6 @@ pub fn build_cursor_elements(
     let screen_pos = canvas_to_screen(CanvasPos(canvas_pos), camera, zoom).0;
     let physical_pos: Point<f64, Physical> = screen_pos.to_physical_precise_round(scale);
 
-    // Separate the status check from mutable state access (Rust 2024 borrow rules)
     let status = state.cursor.cursor_status.clone();
     let mut result = match status {
         CursorImageStatus::Hidden => vec![],
@@ -70,6 +69,7 @@ pub fn build_cursor_elements(
         }
     };
 
+    // Drag-and-drop icon
     if let Some(ref icon) = state.dnd_icon {
         if icon.alive() {
             let pos: Point<i32, Physical> = (
@@ -91,57 +91,6 @@ pub fn build_cursor_elements(
 
     result
 }
-            let hotspot = with_states(surface, |states| {
-                states
-                    .data_map
-                    .get::<CursorImageSurfaceData>()
-                    .map(|d| d.lock().unwrap().hotspot)
-                    .unwrap_or_default()
-            });
-            let pos: Point<i32, Physical> = (
-                (physical_pos.x - hotspot.x as f64) as i32,
-                (physical_pos.y - hotspot.y as f64) as i32,
-            ).into();
-            let elems: Vec<WaylandSurfaceRenderElement<GlesRenderer>> =
-                smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
-                    renderer,
-                    surface,
-                    pos,
-                    Scale::from(1.0),
-                    alpha,
-                    Kind::Cursor,
-                );
-            elems.into_iter().map(|e| OutputRenderElements::CursorSurface(e.into())).collect()
-        }
-        CursorImageStatus::Named(icon) => {
-            build_xcursor_elements(state, renderer, physical_pos, icon.name(), alpha)
-        }
-    };
-
-    let mut dnd_elems = Vec::new();
-    if let Some(ref icon) = state.dnd_icon {
-        if icon.alive() {
-            let pos: Point<i32, Physical> = (
-                physical_pos.x as i32,
-                physical_pos.y as i32,
-            ).into();
-            let surface_elems: Vec<WaylandSurfaceRenderElement<GlesRenderer>> =
-                smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
-                    renderer,
-                    icon,
-                    pos,
-                    Scale::from(1.0),
-                    alpha,
-                    Kind::Cursor,
-                );
-            dnd_elems = surface_elems.into_iter().map(|e| OutputRenderElements::CursorSurface(e.into())).collect();
-        }
-    }
-
-    let mut result = cursor_elems;
-    result.extend(dnd_elems);
-    result
-}
 
 /// Build xcursor memory buffer elements for a named cursor icon.
 fn build_xcursor_elements(
@@ -158,7 +107,6 @@ fn build_xcursor_elements(
     let key = if loaded { name } else { "default" };
     let cursor_frames = state.cursor.cursor_buffers.get(key).unwrap();
 
-    // Select the active frame
     let frame_idx = if cursor_frames.total_duration_ms == 0 {
         0
     } else {

--- a/src/render/cursor.rs
+++ b/src/render/cursor.rs
@@ -36,7 +36,7 @@ pub fn build_cursor_elements(
 
     // Separate the status check from mutable state access (Rust 2024 borrow rules)
     let status = state.cursor.cursor_status.clone();
-    match status {
+    let mut result = match status {
         CursorImageStatus::Hidden => vec![],
         CursorImageStatus::Surface(ref surface) => {
             if !surface.alive() {
@@ -68,7 +68,79 @@ pub fn build_cursor_elements(
         CursorImageStatus::Named(icon) => {
             build_xcursor_elements(state, renderer, physical_pos, icon.name(), alpha)
         }
+    };
+
+    if let Some(ref icon) = state.dnd_icon {
+        if icon.alive() {
+            let pos: Point<i32, Physical> = (
+                physical_pos.x as i32,
+                physical_pos.y as i32,
+            ).into();
+            let surface_elems: Vec<WaylandSurfaceRenderElement<GlesRenderer>> =
+                smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
+                    renderer,
+                    icon,
+                    pos,
+                    Scale::from(1.0),
+                    alpha,
+                    Kind::Cursor,
+                );
+            result.extend(surface_elems.into_iter().map(|e| OutputRenderElements::CursorSurface(e.into())));
+        }
     }
+
+    result
+}
+            let hotspot = with_states(surface, |states| {
+                states
+                    .data_map
+                    .get::<CursorImageSurfaceData>()
+                    .map(|d| d.lock().unwrap().hotspot)
+                    .unwrap_or_default()
+            });
+            let pos: Point<i32, Physical> = (
+                (physical_pos.x - hotspot.x as f64) as i32,
+                (physical_pos.y - hotspot.y as f64) as i32,
+            ).into();
+            let elems: Vec<WaylandSurfaceRenderElement<GlesRenderer>> =
+                smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
+                    renderer,
+                    surface,
+                    pos,
+                    Scale::from(1.0),
+                    alpha,
+                    Kind::Cursor,
+                );
+            elems.into_iter().map(|e| OutputRenderElements::CursorSurface(e.into())).collect()
+        }
+        CursorImageStatus::Named(icon) => {
+            build_xcursor_elements(state, renderer, physical_pos, icon.name(), alpha)
+        }
+    };
+
+    let mut dnd_elems = Vec::new();
+    if let Some(ref icon) = state.dnd_icon {
+        if icon.alive() {
+            let pos: Point<i32, Physical> = (
+                physical_pos.x as i32,
+                physical_pos.y as i32,
+            ).into();
+            let surface_elems: Vec<WaylandSurfaceRenderElement<GlesRenderer>> =
+                smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
+                    renderer,
+                    icon,
+                    pos,
+                    Scale::from(1.0),
+                    alpha,
+                    Kind::Cursor,
+                );
+            dnd_elems = surface_elems.into_iter().map(|e| OutputRenderElements::CursorSurface(e.into())).collect();
+        }
+    }
+
+    let mut result = cursor_elems;
+    result.extend(dnd_elems);
+    result
 }
 
 /// Build xcursor memory buffer elements for a named cursor icon.

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -37,7 +37,7 @@ use smithay::backend::renderer::{
 };
 use smithay::output::Output;
 use smithay::reexports::wayland_server::Resource;
-use smithay::utils::{Logical, Physical, Point, Rectangle, Scale, Size, Transform};
+use smithay::utils::{IsAlive, Logical, Physical, Point, Rectangle, Scale, Size, Transform};
 use smithay::wayland::compositor::with_states;
 use smithay::wayland::seat::WaylandFocus;
 use smithay::wayland::shell::wlr_layer::Layer as WlrLayer;
@@ -145,6 +145,11 @@ pub fn compose_frame(
     output: &Output,
     cursor_elements: Vec<OutputRenderElements>,
 ) -> Vec<OutputRenderElements> {
+    // Clean up dead DnD icon (source destroyed / Esc cancelled)
+    if state.dnd_icon.as_ref().is_some_and(|s| !s.alive()) {
+        state.dnd_icon = None;
+    }
+
     // Session lock: render only lock surface (or black) + cursor
     if !matches!(state.session_lock, crate::state::SessionLock::Unlocked) {
         return compose_lock_frame(state, renderer, output, cursor_elements);

--- a/src/state/init.rs
+++ b/src/state/init.rs
@@ -177,6 +177,7 @@ impl DriftWm {
             data_device_state,
             seat,
             cursor: CursorState::new(),
+            dnd_icon: None,
             backend: None,
             decorations: HashMap::new(),
             pending_ssd: HashSet::new(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -299,6 +299,7 @@ pub struct DriftWm {
 
     // -- global: cursor --
     pub cursor: CursorState,
+    pub dnd_icon: Option<WlSurface>,
 
     // -- global: backend --
     pub backend: Option<Backend>,


### PR DESCRIPTION
Render the DnD icon surface that was previously discarded.

## Change
The `_` prefix on `_icon` meant the drag icon was received but never rendered. Now:
- Set cursor to the icon surface when DnD starts
- Restore default cursor when DnD ends via `DndGrabHandler::dropped`

## Files
- `src/handlers/mod.rs`: +10 lines, 1 file changed

Closes #71