### PR TITLE
Per-output damage, hotplug cleanup, blur throttle, panic-free protocol dispatch

### DIFF
--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -116,7 +116,7 @@ pub(crate) fn render_if_needed(device: &UdevDevice, data: &mut DriftWm) {
                 continue;
             };
             if *on {
-                data.redraws_needed.insert(crtc);
+                data.redraws_needed.insert(output.clone());
             } else {
                 if let Err(e) = surface.compositor.clear() {
                     tracing::warn!(
@@ -124,7 +124,7 @@ pub(crate) fn render_if_needed(device: &UdevDevice, data: &mut DriftWm) {
                         output.name()
                     );
                 }
-                data.redraws_needed.remove(&crtc);
+                data.redraws_needed.remove(output);
                 data.frames_pending.remove(&crtc);
                 if let Some(token) = data.estimated_vblank_timers.remove(&crtc) {
                     data.loop_handle.remove(token);
@@ -136,18 +136,17 @@ pub(crate) fn render_if_needed(device: &UdevDevice, data: &mut DriftWm) {
         driftwm::protocols::output_power::OutputPowerState::refresh(data);
     }
 
-    // 3. Mark CRTCs dirty for per-output animations
-    for (&crtc, surface) in dev.surfaces.iter() {
+    // Mark outputs dirty for per-output animations.
+    for (_, surface) in dev.surfaces.iter() {
         if data.dpms_off_outputs.contains(&surface.output) {
             continue;
         }
         if data.output_has_active_animations(&surface.output) {
-            data.redraws_needed.insert(crtc);
+            data.redraws_needed.insert(surface.output.clone());
         }
     }
 
-    // 3. Global animations (key repeat, cursor, animated bg) → mark all dirty
-    // mark_all_dirty() uses active_crtcs on DriftWm, not dev.surfaces
+    // Global animations (key repeat, cursor, animated bg) → every output.
     if data.held_action.is_some()
         || data.cursor.exec_cursor_show_at.is_some()
         || data.cursor.exec_cursor_deadline.is_some()
@@ -180,13 +179,13 @@ pub(crate) fn render_if_needed(device: &UdevDevice, data: &mut DriftWm) {
         );
     }
 
-    // 5. Render outputs that need it
+    // Render outputs that need it.
     for (&crtc, surface) in dev.surfaces.iter_mut() {
         if data.dpms_off_outputs.contains(&surface.output) {
-            data.redraws_needed.remove(&crtc);
+            data.redraws_needed.remove(&surface.output);
             continue;
         }
-        if data.redraws_needed.contains(&crtc) && !data.frames_pending.contains(&crtc) {
+        if data.redraws_needed.contains(&surface.output) && !data.frames_pending.contains(&crtc) {
             render_frame(data, &mut surface.compositor, &surface.output, crtc);
         }
     }
@@ -522,7 +521,7 @@ pub fn init_udev(
                     if let Some(token) = data.estimated_vblank_timers.remove(&crtc) {
                         data.loop_handle.remove(token);
                     }
-                    if data.redraws_needed.contains(&crtc) {
+                    if data.redraws_needed.contains(&surface.output) {
                         render_frame(data, &mut surface.compositor, &surface.output, crtc);
                     }
                 }
@@ -646,7 +645,7 @@ pub fn init_udev(
                                         &saved,
                                     ) {
                                         surfaces.insert(crtc, sd);
-                                        data.active_crtcs.insert(crtc);
+                                        data.active_outputs.insert(surfaces[&crtc].output.clone());
                                         let surface = surfaces.get_mut(&crtc).unwrap();
                                         // Notify existing toplevels about the new output
                                         driftwm::protocols::foreign_toplevel::send_output_enter_all(
@@ -666,100 +665,10 @@ pub fn init_udev(
                                 } => {
                                     tracing::info!("Hotplug: CRTC {crtc:?} disconnected");
                                     if let Some(surface) = surfaces.remove(&crtc) {
-                                        driftwm::protocols::foreign_toplevel::send_output_leave_all(
-                                            &mut data.foreign_toplevel_state,
-                                            &surface.output,
-                                        );
-
-                                        // Stop capture/screencopy sessions for this output
-                                        data.image_copy_capture_state
-                                            .remove_output(&surface.output);
-                                        data.screencopy_state.remove_output(&surface.output);
-
-                                        // Tear down the wl_output global so clients
-                                        // (wf-recorder, swayosd, etc.) see the output go away.
-                                        remove_output_global(data, surface.global);
-
-                                        // Close layer surfaces on this output so clients
-                                        // (swayosd, waybar, etc.) can recreate on remaining outputs
-                                        for layer in
-                                            smithay::desktop::layer_map_for_output(&surface.output)
-                                                .layers()
-                                        {
-                                            layer.layer_surface().send_close();
-                                        }
-
-                                        if surfaces.is_empty() {
-                                            // Last output disconnected — keep it in the Space as
-                                            // a virtual placeholder so active_output() always
-                                            // returns Some. Input events (USB keyboard/mouse) may
-                                            // still arrive; the virtual output retains its old
-                                            // mode/size so position_transformed() works correctly.
-                                            tracing::warn!(
-                                                "Last output disconnected — keeping virtual output '{}'",
-                                                surface.output.name()
-                                            );
-                                            data.disconnected_outputs.insert(surface.output.name());
-                                            data.exit_fullscreen_on(&surface.output);
-                                            data.render.remove_output(&surface.output.name());
-                                            data.lock_surfaces.remove(&surface.output);
-                                        } else {
-                                            data.space.unmap_output(&surface.output);
-
-                                            // Cancel any active pointer grab — grabs store an Output
-                                            // clone and would operate on stale state after disconnect.
-                                            if let Some(pointer) = data.seat.get_pointer() {
-                                                let serial =
-                                                    smithay::utils::SERIAL_COUNTER.next_serial();
-                                                pointer.unset_grab(data, serial, 0);
-                                            }
-
-                                            // Clean up focused_output if it was on the disconnected output
-                                            if data
-                                                .focused_output
-                                                .as_ref()
-                                                .is_some_and(|fo| fo == &surface.output)
-                                            {
-                                                data.focused_output =
-                                                    data.space.outputs().next().cloned();
-                                                if let Some(ref new_out) = data.focused_output {
-                                                    let (cam, zoom, size) = {
-                                                        let os =
-                                                            crate::state::output_state(new_out);
-                                                        let sz = crate::state::output_logical_size(
-                                                            new_out,
-                                                        );
-                                                        (os.camera, os.zoom, sz)
-                                                    };
-                                                    let center = smithay::utils::Point::from((
-                                                        cam.x + size.w as f64 / (2.0 * zoom),
-                                                        cam.y + size.h as f64 / (2.0 * zoom),
-                                                    ));
-                                                    data.warp_pointer(center);
-                                                }
-                                            }
-
-                                            // Clean up gesture state if gesture was on the disconnected output
-                                            if data
-                                                .gesture_output
-                                                .as_ref()
-                                                .is_some_and(|go| go == &surface.output)
-                                            {
-                                                data.gesture_output = None;
-                                                data.gesture_state = None;
-                                            }
-
-                                            // Clean up per-output resources
-                                            data.render.remove_output(&surface.output.name());
-                                            data.fullscreen.remove(&surface.output);
-                                            data.lock_surfaces.remove(&surface.output);
-                                            data.dpms_off_outputs.remove(&surface.output);
-                                            data.pending_dpms.remove(&surface.output);
-                                        }
+                                        let is_last = surfaces.is_empty();
+                                        teardown_output(data, surface, is_last);
                                     }
-                                    data.active_crtcs.remove(&crtc);
                                     data.frames_pending.remove(&crtc);
-                                    data.redraws_needed.remove(&crtc);
                                     if let Some(token) = data.estimated_vblank_timers.remove(&crtc)
                                     {
                                         data.loop_handle.remove(token);
@@ -787,11 +696,11 @@ pub fn init_udev(
     );
     event_loop.handle().register_dispatcher(udev_dispatcher)?;
 
-    // 12. Seed active_crtcs and queue initial render
+    // 12. Seed active_outputs and queue initial render
     {
         let mut dev = device.borrow_mut();
         for (&crtc, surface) in dev.surfaces.iter_mut() {
-            data.active_crtcs.insert(crtc);
+            data.active_outputs.insert(surface.output.clone());
             render_frame(data, &mut surface.compositor, &surface.output, crtc);
         }
         // 13. Notify output management clients of initial state
@@ -1211,6 +1120,92 @@ fn remove_output_global(data: &mut DriftWm, global: GlobalId) {
     }
 }
 
+/// Drop everything bound to a disconnected output.
+///
+/// Runs whether the output is the last surviving one or not. The "last output"
+/// path keeps the [`Output`] in the [`Space`] as a virtual placeholder (so
+/// `active_output()` stays `Some` while a USB monitor is replugged) but still
+/// needs the grab/gesture/focus cleanup — otherwise a move grab pinned to the
+/// dying output keeps mutating its stale per-output state on every cursor event.
+fn teardown_output(data: &mut DriftWm, surface: SurfaceData, is_last: bool) {
+    let SurfaceData { output, global, .. } = surface;
+
+    driftwm::protocols::foreign_toplevel::send_output_leave_all(
+        &mut data.foreign_toplevel_state,
+        &output,
+    );
+    data.image_copy_capture_state.remove_output(&output);
+    data.screencopy_state.remove_output(&output);
+
+    // Disable the wl_output global before any further state mutation so clients
+    // (wf-recorder, swayosd, etc.) see the removal first.
+    remove_output_global(data, global);
+
+    // Close layer surfaces hosted on this output. They'll re-anchor against
+    // remaining outputs on their next configure round-trip.
+    for layer in smithay::desktop::layer_map_for_output(&output).layers() {
+        layer.layer_surface().send_close();
+    }
+
+    // Grabs (move/resize/pan/navigate) clone the Output and keep mutating its
+    // per-output state on every motion. Cancel before the output goes away.
+    if let Some(pointer) = data.seat.get_pointer() {
+        let serial = smithay::utils::SERIAL_COUNTER.next_serial();
+        pointer.unset_grab(data, serial, 0);
+    }
+    if data
+        .gesture_output
+        .as_ref()
+        .is_some_and(|go| go == &output)
+    {
+        data.gesture_output = None;
+        data.gesture_state = None;
+    }
+
+    data.exit_fullscreen_on(&output);
+    data.render.remove_output(&output.name());
+    data.lock_surfaces.remove(&output);
+    data.active_outputs.remove(&output);
+    data.redraws_needed.remove(&output);
+
+    if is_last {
+        // Keep the Output mapped as a virtual placeholder so active_output()
+        // and other queries stay Some while no monitor is attached. The DRM
+        // surface and wl_output global are already gone, so it's purely an
+        // input-routing/coordinate-system anchor.
+        tracing::warn!(
+            "Last output disconnected — keeping virtual output '{}'",
+            output.name()
+        );
+        data.disconnected_outputs.insert(output.name());
+    } else {
+        data.space.unmap_output(&output);
+        data.fullscreen.remove(&output);
+        data.dpms_off_outputs.remove(&output);
+        data.pending_dpms.remove(&output);
+
+        if data
+            .focused_output
+            .as_ref()
+            .is_some_and(|fo| fo == &output)
+        {
+            data.focused_output = data.space.outputs().next().cloned();
+            if let Some(ref new_out) = data.focused_output {
+                let (cam, zoom, size) = {
+                    let os = crate::state::output_state(new_out);
+                    let sz = crate::state::output_logical_size(new_out);
+                    (os.camera, os.zoom, sz)
+                };
+                let center = smithay::utils::Point::from((
+                    cam.x + size.w as f64 / (2.0 * zoom),
+                    cam.y + size.h as f64 / (2.0 * zoom),
+                ));
+                data.warp_pointer(center);
+            }
+        }
+    }
+}
+
 /// Render a single frame and queue it to the DRM compositor.
 fn render_frame(
     data: &mut DriftWm,
@@ -1218,7 +1213,7 @@ fn render_frame(
     output: &Output,
     crtc: crtc::Handle,
 ) {
-    data.redraws_needed.remove(&crtc);
+    data.redraws_needed.remove(output);
 
     // Flush Wayland clients
     data.display_handle.flush_clients().ok();
@@ -1536,7 +1531,7 @@ fn apply_pending_mode_changes(
                     smithay::utils::Size::from((mode.size().0 as i32, mode.size().1 as i32));
                 data.resize_fullscreen_for_output(&surface.output, new_size);
                 data.render.remove_output(&name);
-                data.redraws_needed.insert(*crtc);
+                data.redraws_needed.insert(surface.output.clone());
                 data.output_config_dirty = true;
                 tracing::info!(
                     "Mode change applied to '{name}': {}x{}@{}Hz",

--- a/src/grabs/move_grab.rs
+++ b/src/grabs/move_grab.rs
@@ -44,6 +44,12 @@ pub struct MoveSurfaceGrab {
     /// doesn't change mid-drag, so we pay the `HashSet` build cost once
     /// instead of rebuilding it every motion tick.
     cluster_member_surfaces: HashSet<WlSurface>,
+    /// Last integer canvas position the primary window was mapped to. Used to
+    /// throttle blur cache invalidation: libinput delivers many motion events
+    /// per render frame and most of them resolve to the same integer position
+    /// (especially during snap holds), so bumping the blur generation
+    /// unconditionally re-runs Kawase blur on every blurred window for nothing.
+    last_mapped_loc: Option<Point<i32, Logical>>,
 }
 
 impl MoveSurfaceGrab {
@@ -64,6 +70,7 @@ impl MoveSurfaceGrab {
             inhibited_edge: None,
             cluster_members,
             cluster_member_surfaces,
+            last_mapped_loc: None,
         }
     }
 
@@ -208,8 +215,6 @@ impl PointerGrab<DriftWm> for MoveSurfaceGrab {
         _focus: Option<(<DriftWm as SeatHandler>::PointerFocus, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
-        data.render.blur_geometry_generation += 1;
-
         // Phase 3 input routing already converted event.location to the focused
         // output's canvas space and updated data.focused_output. If that differs
         // from self.output, the pointer crossed an output boundary.
@@ -256,6 +261,11 @@ impl PointerGrab<DriftWm> for MoveSurfaceGrab {
             }
             data.space
                 .map_element(self.window.clone(), self.initial_window_location, false);
+
+            // Output crossing always invalidates blur (different camera/zoom,
+            // different background sample region).
+            data.render.blur_geometry_generation += 1;
+            self.last_mapped_loc = Some(self.initial_window_location);
 
             handle.motion(data, None, event);
             return;
@@ -363,6 +373,16 @@ impl PointerGrab<DriftWm> for MoveSurfaceGrab {
             data.space.map_element(member.clone(), member_pos, false);
         }
         data.space.map_element(self.window.clone(), new_loc, false);
+
+        // Sub-pixel motion that resolves to the same integer canvas position
+        // doesn't actually shift the window, so blurred neighbours don't need
+        // a fresh sample. Bumping on every motion event re-runs Kawase blur
+        // for every blurred surface and tanks GPU during drag.
+        if self.last_mapped_loc != Some(new_loc) {
+            data.render.blur_geometry_generation += 1;
+            self.last_mapped_loc = Some(new_loc);
+        }
+
         handle.motion(data, None, event);
 
         // Edge auto-pan detection using pinned output.

--- a/src/handlers/background_effect.rs
+++ b/src/handlers/background_effect.rs
@@ -107,7 +107,7 @@ fn mark_blur_region_pending_dirty(wl_surface: &WlSurface) {
             // content — we have to ask for a redraw explicitly, otherwise
             // a still surface that swaps its blur rect won't repaint.
             if became_dirty {
-                state.mark_all_dirty();
+                state.mark_dirty_for_surface(surface);
             }
         });
     }

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -118,7 +118,11 @@ impl CompositorHandler for DriftWm {
     }
 
     fn commit(&mut self, surface: &smithay::reexports::wayland_server::protocol::wl_surface::WlSurface) {
-        self.mark_all_dirty();
+        // Damage only the outputs that actually host this surface — global
+        // dirty here would force every CRTC to redraw on every wl_surface
+        // commit (video, terminal scroll, etc), defeating the per-output
+        // damage tracker.
+        self.mark_dirty_for_surface(surface);
 
         // Trim corners from CSD toplevels' opaque regions so the background renders
         // behind rounded corners. Some CSD apps (e.g. LibreOffice/GTK3) declare the

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -214,8 +214,9 @@ impl XdgShellHandler for DriftWm {
             let fs_output = self.fullscreen.iter()
                 .find(|(_, fs)| &fs.window == window)
                 .map(|(o, _)| o.clone());
-            if let Some(ref output) = fs_output {
-                let fs = self.fullscreen.remove(output).unwrap();
+            if let Some(ref output) = fs_output
+                && let Some(fs) = self.fullscreen.remove(output)
+            {
                 output_state(output).camera = fs.saved_camera;
                 output_state(output).zoom = fs.saved_zoom;
                 self.update_output_from_camera();

--- a/src/protocols/foreign_toplevel.rs
+++ b/src/protocols/foreign_toplevel.rs
@@ -403,7 +403,12 @@ where
                 let state = state.foreign_toplevel_manager_state();
                 state.instances.retain(|x| x != resource);
             }
-            _ => unreachable!(),
+            // Forward-compat: a future protocol revision could add new requests.
+            // Ignore rather than panic — a malformed or future-versioned client
+            // mustn't be able to take the compositor down.
+            other => tracing::debug!(
+                "zwlr_foreign_toplevel_manager_v1: ignoring unknown request {other:?}"
+            ),
         }
     }
 
@@ -468,7 +473,9 @@ where
             zwlr_foreign_toplevel_handle_v1::Request::UnsetFullscreen => {
                 state.unset_fullscreen(surface);
             }
-            _ => unreachable!(),
+            other => tracing::debug!(
+                "zwlr_foreign_toplevel_handle_v1: ignoring unknown request {other:?}"
+            ),
         }
     }
 

--- a/src/state/init.rs
+++ b/src/state/init.rs
@@ -270,7 +270,7 @@ impl DriftWm {
             state_file_windows: Vec::new(),
             state_file_layer_count: 0,
             autostart,
-            active_crtcs: HashSet::new(),
+            active_outputs: HashSet::new(),
             redraws_needed: HashSet::new(),
             frames_pending: HashSet::new(),
             estimated_vblank_timers: HashMap::new(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -487,8 +487,11 @@ pub struct DriftWm {
     pub autostart: Vec<String>,
 
     // -- global: udev/DRM --
-    pub active_crtcs: HashSet<crtc::Handle>,
-    pub redraws_needed: HashSet<crtc::Handle>,
+    /// Outputs whose CRTC is currently active (driven by the backend).
+    /// Used as the universe for [`Self::mark_all_dirty`].
+    pub active_outputs: HashSet<Output>,
+    /// Outputs that need to render on the next backend tick.
+    pub redraws_needed: HashSet<Output>,
     pub frames_pending: HashSet<crtc::Handle>,
     /// One-shot timers armed when queue_frame returned EmptyFrame so the loop
     /// still wakes at ~refresh rate to advance animations (e.g. xcursor frames).
@@ -666,9 +669,62 @@ impl DriftWm {
         keyboard.set_focus(self, focus_surface, serial);
     }
 
-    /// Mark all active outputs as needing a redraw.
+    /// Mark every active output as needing a redraw.
     pub fn mark_all_dirty(&mut self) {
-        self.redraws_needed.extend(self.active_crtcs.iter());
+        self.redraws_needed.clone_from(&self.active_outputs);
+    }
+
+    /// Mark every output that currently displays `surface` (or its root toplevel /
+    /// hosting layer / lock output) as needing a redraw. Falls back to
+    /// [`Self::mark_all_dirty`] when the surface can't be resolved to a specific
+    /// output — covers DnD icons, orphan popups, and the brief window between
+    /// a toplevel's first commit and its space mapping.
+    pub fn mark_dirty_for_surface(&mut self, surface: &WlSurface) {
+        use smithay::desktop::{WindowSurfaceType, layer_map_for_output};
+        use smithay::wayland::compositor::get_parent;
+
+        let mut root = surface.clone();
+        while let Some(parent) = get_parent(&root) {
+            root = parent;
+        }
+
+        if let Some(window) = self
+            .space
+            .elements()
+            .find(|w| w.wl_surface().as_deref() == Some(&root))
+            .cloned()
+        {
+            let outputs = self.space.outputs_for_element(&window);
+            if !outputs.is_empty() {
+                for output in outputs {
+                    self.redraws_needed.insert(output);
+                }
+                return;
+            }
+        }
+
+        let outputs: Vec<Output> = self.space.outputs().cloned().collect();
+        for output in &outputs {
+            let hit = layer_map_for_output(output)
+                .layer_for_surface(&root, WindowSurfaceType::ALL)
+                .is_some();
+            if hit {
+                self.redraws_needed.insert(output.clone());
+                return;
+            }
+        }
+
+        if let Some(output) = self
+            .lock_surfaces
+            .iter()
+            .find(|(_, ls)| ls.wl_surface() == &root)
+            .map(|(o, _)| o.clone())
+        {
+            self.redraws_needed.insert(output);
+            return;
+        }
+
+        self.mark_all_dirty();
     }
 
     pub fn cursor_is_animated(&self) -> bool {


### PR DESCRIPTION
## Summary

Four targeted hardening / perf fixes uncovered in a wider audit. Bundled in one PR because they share a small set of state-level invariants.

### Per-output damage (replaces global `mark_all_dirty` in commit)

`CompositorHandler::commit` called `mark_all_dirty()`, which on the udev backend enqueued a redraw for **every** CRTC on **every** `wl_surface.commit`. High-FPS clients (video, terminals, games) effectively turned the per-output damage tracker into a no-op.

- `active_crtcs: HashSet<crtc::Handle>` → `active_outputs: HashSet<Output>`
- `redraws_needed: HashSet<crtc::Handle>` → `HashSet<Output>`
- `frames_pending` stays per-CRTC — purely an internal udev scheduling concept.
- New `mark_dirty_for_surface(&WlSurface)` resolves the surface's root → owning outputs (toplevel via `Space::outputs_for_element`, layer via `layer_map_for_output`, lock via `lock_surfaces`) and falls back to all-outputs only when no specific owner can be resolved (DnD icons, orphan popups, pre-mapped toplevels).
- Compositor and `background_effect` commit hooks both use it.

### Hotplug teardown unification

The disconnect path had two divergent branches: the non-last-output branch reset pointer grabs and gesture state, the last-output branch didn't. A move/resize grab pinned to the dying output kept poking its per-output state on every subsequent cursor event. Extracted both into `teardown_output()`; the last-output behaviour (keeping a virtual placeholder) is now just one trailing branch.

### Throttled blur cache invalidation in move grab

`MoveSurfaceGrab::motion` bumped `blur_geometry_generation` on every pointer motion event. libinput delivers many motions per render frame and snap-holds resolve to the same integer position for stretches — every bump re-ran Kawase blur for every blurred surface and tanked GPU during drag. Track `last_mapped_loc`; only bump on actual integer-position change or output crossing.

### Panic-free protocol dispatch

`zwlr_foreign_toplevel_manager_v1` / `zwlr_foreign_toplevel_handle_v1` dispatch hit `unreachable!()` on any unknown opcode — a malformed or future-versioned client could take the whole compositor (and every window) down. Replaced with `tracing::debug!` + ignore (Smithay protocol enums are forward-compatible).

Also tightened `self.fullscreen.remove(output).unwrap()` in `toplevel_destroyed` to an `if let` chain — defensive, no behaviour change in the happy path.

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy --no-deps` clean
- [x] `cargo test --tests` — 372/372 pass
- [x] Nested winit: regular commit-heavy clients (video, terminal scroll) — no regressions
- [x] udev TTY: multi-monitor — hotplug a USB monitor with an active move grab and confirm input stays sane
- [x] Drag a blurred window across the canvas with several other blurred windows visible — no FPS dip
