### PR TITLE
Remove legacy shader_path and tile_path support

### DIFF
--- a/config.reference.toml
+++ b/config.reference.toml
@@ -200,10 +200,6 @@
 # # path = "/usr/local/share/driftwm/wallpapers/textured/ripple.glsl"
 # # texture = "~/Pictures/Wallpapers/photo.jpg"
 #
-# Legacy (still works, prefer the form above):
-# # shader_path = "..."
-# # tile_path   = "..."
-#
 # cache_shader = false
 #   Bake a heavy static shader to a texture once, then pan that — so it pans as
 #   cheaply as an image instead of recomputing every frame.

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -198,15 +198,6 @@ path = "~/Pictures/wallpaper.png"
 The `wallpaper` mode stretches the image to fill the output. Pick an image
 sized to your monitor for best results.
 
-### Legacy fields
-
-`shader_path` and `tile_path` are still accepted for backwards compatibility
-and behave like `type = "shader"` and `type = "tile"` respectively. They log
-an info-level deprecation hint at startup; prefer `type` + `path` in new
-configs.
-
-If both `type` and a legacy field are set, `type` wins.
-
 ## Reloading after edits
 
 The config is automatically reloaded when the file changes. The shader is

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 mod defaults;
+
 mod parse;
 mod parse_helpers;
 mod toml;
@@ -631,18 +632,10 @@ fn resolve_background_kind(raw: toml::BackgroundFileConfig) -> BackgroundKind {
         kind,
         path,
         texture,
-        shader_path,
-        tile_path,
         cache_shader: _,
         cache_budget_mb: _,
     } = raw;
     let texture = texture.as_deref().map(expand_tilde);
-    if kind.is_some() && (shader_path.is_some() || tile_path.is_some()) {
-        tracing::warn!(
-            "[background] both `type` and a legacy `shader_path`/`tile_path` are set; \
-             the new `type`/`path` takes precedence"
-        );
-    }
     if let Some(t) = kind.as_deref() {
         return match (t, path) {
             ("shader", Some(p)) => BackgroundKind::Shader {
@@ -660,19 +653,6 @@ fn resolve_background_kind(raw: toml::BackgroundFileConfig) -> BackgroundKind {
                 BackgroundKind::Default
             }
         };
-    }
-    if let Some(p) = shader_path {
-        tracing::info!(
-            "[background] `shader_path` is deprecated, prefer `type = \"shader\"` + `path`"
-        );
-        return BackgroundKind::Shader {
-            path: expand_tilde(&p),
-            texture,
-        };
-    }
-    if let Some(p) = tile_path {
-        tracing::info!("[background] `tile_path` is deprecated, prefer `type = \"tile\"` + `path`");
-        return BackgroundKind::Tile(expand_tilde(&p));
     }
     BackgroundKind::Default
 }

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -167,8 +167,6 @@ pub(super) struct BackgroundFileConfig {
     pub path: Option<String>,
     /// Optional image sampled by a `type = "shader"` background via `tex`.
     pub texture: Option<String>,
-    pub shader_path: Option<String>,
-    pub tile_path: Option<String>,
     pub cache_shader: Option<bool>,
     pub cache_budget_mb: Option<u32>,
 }

--- a/tests/config_toml_test.rs
+++ b/tests/config_toml_test.rs
@@ -326,22 +326,6 @@ fn toml_cycle_modifier_ctrl() {
 }
 
 #[test]
-fn toml_background_tilde_expansion() {
-    let toml = r#"
-        [background]
-        shader_path = "~/shaders/bg.frag"
-    "#;
-    let config = Config::from_toml(toml).unwrap();
-    match config.background.kind {
-        BackgroundKind::Shader { path, texture } => {
-            assert!(!path.starts_with("~"), "tilde should be expanded");
-            assert_eq!(texture, None);
-        }
-        other => panic!("expected BackgroundKind::Shader from legacy shader_path, got {other:?}"),
-    }
-}
-
-#[test]
 fn toml_background_new_form_wallpaper() {
     let toml = r#"
         [background]
@@ -367,21 +351,6 @@ fn toml_background_unknown_type_falls_back_to_default() {
     "#;
     let config = Config::from_toml(toml).unwrap();
     assert_eq!(config.background.kind, BackgroundKind::Default);
-}
-
-#[test]
-fn toml_background_type_overrides_legacy() {
-    let toml = r#"
-        [background]
-        type = "wallpaper"
-        path = "/tmp/wp.png"
-        shader_path = "/tmp/sh.glsl"
-    "#;
-    let config = Config::from_toml(toml).unwrap();
-    assert!(matches!(
-        config.background.kind,
-        BackgroundKind::Wallpaper(_)
-    ));
 }
 
 #[test]


### PR DESCRIPTION
I laughed a little. This project has only been out for a few months, there's no reason for this

- Removed `shader_path` and `tile_path` from `BackgroundFileConfig`
- Removed legacy fallback logic in `resolve_background_kind()`
- Removed corresponding tests and docs