### PR TITLE
fix: make client fullscreen re-assert idempotent

### DIFF
--- a/src/state/fullscreen.rs
+++ b/src/state/fullscreen.rs
@@ -22,7 +22,24 @@ impl DriftWm {
             return;
         };
 
-        // If already fullscreen on this output, exit first
+        // A client re-asserting fullscreen must be idempotent. A toolkit that
+        // re-sends a fullscreen request while already fullscreen (e.g. osu! on
+        // focus changes) would otherwise hit the exit+re-enter path below, which
+        // recaptures `saved_size` from the window's *current* geometry — which
+        // is the fullscreen viewport size, since the windowed buffer was never
+        // committed in between. That corrupts saved_size to the full viewport,
+        // so a later exit "restores" to full size and toggling fullscreen can
+        // never recover. Re-send the configure and keep the existing saved_*.
+        if self
+            .fullscreen
+            .get(&output)
+            .is_some_and(|fs| &fs.window == window)
+        {
+            window.enter_fullscreen_configure(self.get_viewport_size());
+            return;
+        }
+
+        // A different window is taking over this output's fullscreen: exit first.
         if self.fullscreen.contains_key(&output) {
             self.exit_fullscreen();
         }


### PR DESCRIPTION
## Problem

A fullscreen game (reproduced with **osu!**, a native Wayland/SDL client) gets visually corrupted when fullscreen is toggled: after setting fullscreen from in-game, pressing the fullscreen keybind (`Super+F`) breaks rendering, and toggling again never recovers it.

## Root cause

`enter_fullscreen` already handles "replace the fullscreen window on this output" by exiting first:

```rust
// If already fullscreen on this output, exit first
if self.fullscreen.contains_key(&output) {
    self.exit_fullscreen();
}
```

But this also fires when **the same window re-asserts fullscreen** while already fullscreen — which toolkits do (e.g. osu! re-sends its fullscreen request on focus changes). The synthetic `exit_fullscreen()` followed by re-entry recaptures `saved_size` from the window's *current* geometry:

```rust
let saved_size = ... window.geometry().size ...;
```

At that instant the geometry is still the **fullscreen viewport size** — the windowed buffer was never committed between the synthetic exit and the immediate re-enter. So `saved_size` is corrupted to the full viewport. From then on, every `exit_fullscreen` "restores" the window at full-viewport size, so it looks stuck-fullscreen and toggling `Super+F` cycles viewport→viewport, never recovering.

## Fix

Make a redundant fullscreen request for the window **already fullscreen on that output** idempotent: just re-send the configure and keep the existing `saved_*` state. The exit-first path still runs only when a *different* window takes over the output's fullscreen.

```rust
if self.fullscreen.get(&output).is_some_and(|fs| &fs.window == window) {
    window.enter_fullscreen_configure(self.get_viewport_size());
    return;
}
```

## Testing

- `cargo build`, `cargo fmt --check` clean.
- Manually verified with osu! (AppImage, native Wayland): fullscreen from in-game → `Super+F` now exits cleanly and re-toggling re-enters without corruption. Before the fix the window stayed full-size and was unrecoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)