### PR TITLE
fix: keep self-minimizing clients responsive

### DIFF
--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -199,6 +199,22 @@ impl XdgShellHandler for DriftWm {
         }
     }
 
+    // driftwm has no minimize concept (infinite canvas, no taskbar-backed
+    // hide/restore — see foreign_toplevel SetMinimized). But a client that
+    // minimizes itself stalls otherwise: the toolkit stops drawing and waits
+    // to be reactivated. xdg-shell carries no "minimized" state, so the toolkit
+    // only clears its internal minimized flag on a configure with `Activated` —
+    // which driftwm never sends on plain focus. Bounce the window back to
+    // active: refuse the minimize and force a wake-up configure so it stays
+    // responsive instead of freezing until the next size-changing configure.
+    fn minimize_request(&mut self, surface: ToplevelSurface) {
+        use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
+        surface.with_pending_state(|state| {
+            state.states.set(xdg_toplevel::State::Activated);
+        });
+        surface.send_configure();
+    }
+
     fn toplevel_destroyed(&mut self, surface: ToplevelSurface) {
         let wl_surface = surface.wl_surface().clone();
         self.decorations.remove(&wl_surface.id());


### PR DESCRIPTION
## Problem

A client that minimizes itself (`xdg_toplevel.set_minimized`) freezes: the window stays on the canvas but stops drawing and ignores input. The only way to revive it was an unrelated size-changing configure — e.g. toggling fullscreen (`Super+F`) on and off.

## Root cause

driftwm has no minimize concept by design (infinite canvas, no taskbar-backed hide/restore; `foreign_toplevel` `SetMinimized` is already a no-op). So `XdgShellHandler::minimize_request` falls through to smithay's empty default and **nothing happens** compositor-side.

But the *client* doesn't know that. On `set_minimized`, toolkits (GTK/Qt/SDL) enter an internal minimized/inactive state and stop rendering, waiting for the compositor to reactivate them. xdg-shell carries no "minimized" state in the toplevel configure, so a toolkit only clears that internal flag when it receives a configure that includes the **`Activated`** state — which driftwm never sends on a plain focus change (it only ever sets `Fullscreen`/`Maximized`). Result: the window is stuck until some other path happens to send a configure (the fullscreen toggle changes the size, which forces the toolkit to reconfigure and resume).

## Fix

Implement `minimize_request` to bounce the window back to active: set the `Activated` state and send a configure. The minimize is effectively refused — consistent with the no-minimize design — and the client wakes immediately instead of freezing.

```rust
fn minimize_request(&mut self, surface: ToplevelSurface) {
    use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
    surface.with_pending_state(|state| {
        state.states.set(xdg_toplevel::State::Activated);
    });
    surface.send_configure();
}
```

## Testing

- `cargo build`, `cargo fmt --check` clean.
- Branched on current `main` (v0.9.0); self-contained (one handler method).
- Manually verified: a window that triggers minimize no longer freezes — it stays responsive instead of requiring a fullscreen toggle to recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)