### PR TITLE
Add send-cursor-to-output <dir>

### DIFF
--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -162,6 +162,10 @@ pub fn parse_action(s: &str) -> Result<Action, String> {
             let dir = parse_direction(arg.ok_or("send-to-output requires a direction")?)?;
             Ok(Action::SendToOutput(dir))
         }
+        "send-cursor-to-output" => {
+            let dir = parse_direction(arg.ok_or("send-cursor-to-output requires a direction")?)?;
+            Ok(Action::SendCursorToOutput(dir))
+        }
         "switch-layout" => {
             let arg = arg.ok_or("switch-layout requires next, prev, or a layout index")?;
             let target = match arg.trim().to_lowercase().as_str() {
@@ -325,6 +329,7 @@ fn parse_threshold_action(s: &str) -> Result<Option<ThresholdAction>, String> {
         s if s.starts_with("exec ")
             || s.starts_with("spawn ")
             || s.starts_with("send-to-output ")
+            || s.starts_with("send-cursor-to-output ")
             || s.starts_with("switch-layout ") =>
         {
             let action = parse_action(s)?;

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -68,6 +68,7 @@ pub enum Action {
     FitWindow,
     FitWindowSnapped,
     SendToOutput(Direction),
+    SendCursorToOutput(Direction),
     FocusCenter,
     TogglePinToScreen,
     SwitchLayout(LayoutSwitch),

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -1,7 +1,7 @@
 use smithay::{
     input::{keyboard::Layout, pointer::MotionEvent},
     reexports::wayland_server::Resource,
-    utils::{Point, SERIAL_COUNTER, Size},
+    utils::{Logical, Point, SERIAL_COUNTER, Size},
     wayland::seat::WaylandFocus,
 };
 
@@ -416,6 +416,55 @@ impl DriftWm {
                     let serial = smithay::utils::SERIAL_COUNTER.next_serial();
                     self.raise_and_focus(&window, serial);
                 }
+            }
+            Action::SendCursorToOutput(dir) => {
+                let pointer = self.seat.get_pointer().unwrap();
+                let pos = pointer.current_location();
+
+                // Find which output the cursor is currently over by checking
+                // each output's visible canvas rect. Mirrors output_for_window
+                // but for the cursor's canvas-space position.
+                let from_output = self
+                    .space
+                    .outputs()
+                    .find(|o| {
+                        let os = crate::state::output_state(o);
+                        let size = crate::state::output_logical_size(o);
+                        let visible = driftwm::canvas::visible_canvas_rect(
+                            os.camera.to_i32_round(),
+                            size,
+                            os.zoom,
+                        );
+                        drop(os);
+                        visible.contains(Point::<i32, Logical>::from((pos.x as i32, pos.y as i32)))
+                    })
+                    .cloned()
+                    .or_else(|| self.active_output());
+
+                let Some(from_output) = from_output else { return };
+                let Some(target_output) = self.output_in_direction(&from_output, dir) else {
+                    return;
+                };
+
+                // Center of the target output's usable area in canvas coords.
+                // Excludes layer-shell exclusive zones (panels) — same anchor
+                // send-to-output and window_placement = "center" use, so a
+                // panned cursor lands where new windows would.
+                let (target_cam, target_zoom) = {
+                    let os = crate::state::output_state(&target_output);
+                    (os.camera, os.zoom)
+                };
+                let target_vc = crate::state::usable_center_for_output(&target_output);
+                let target_canvas = Point::<f64, Logical>::from((
+                    target_cam.x + target_vc.x / target_zoom,
+                    target_cam.y + target_vc.y / target_zoom,
+                ));
+
+                self.warp_pointer(target_canvas);
+                // Match what input/mod.rs:675 does on real cursor moves so the
+                // next action (center-nearest, focus, etc.) targets the new
+                // output even though no real motion event happened.
+                self.focused_output = Some(target_output);
             }
             Action::SwitchLayout(target) => {
                 // with_xkb_state broadcasts the layout/modifier change to the


### PR DESCRIPTION
https://github.com/malbiruk/driftwm/issues/156
AI made
send-cursor-to-output <dir>  - move cursor to adjacent output
