### PR TITLE
feat: Add touchscreen support and multi-touch canvas gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center"><img alt="driftwm" src="assets/logo.jpg" width="500"></h1>
-<p align="center">A trackpad-first infinite canvas Wayland compositor.</p>
+<p align="center">A trackpad-first and touchscreen-friendly infinite canvas Wayland compositor.</p>
 <p align="center">
     <a href="https://github.com/malbiruk/driftwm/blob/main/LICENSE"><img alt="License: GPL-3.0-or-later" src="https://img.shields.io/badge/license-GPL--3.0--or--later-blue"></a>
     <a href="https://github.com/malbiruk/driftwm/releases"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/malbiruk/driftwm?logo=github"></a>
@@ -13,7 +13,7 @@ Traditional window managers arrange windows to fit your screen. Stacking composi
 
 `driftwm` is an infinite-canvas compositor: windows live at their native size on an infinite 2D canvas, and your display is a camera viewing it. When two windows come close, they snap together, forming implicit groups that can be moved, resized, and viewed together. No tiling, no workspaces, window overlaps happen only on purpose.
 
-Designed with laptops in mind: navigation and window management are trackpad-first; the infinite canvas makes the most of a small screen.
+Designed with laptops and touch screens in mind: navigation and window management are trackpad-first (with native touchscreen support); the infinite canvas makes the most of a small screen.
 
 Built on [smithay](https://github.com/Smithay/smithay). Inspired by [vxwm](https://codeberg.org/wh1tepearl/vxwm); borrows implementation details from [niri](https://github.com/YaLTeR/niri).
 
@@ -42,6 +42,8 @@ flick carries the viewport smoothly until friction stops it.
 | `Mod` + scroll     | Zoom at cursor    | anywhere  |
 | `Mod+=` / `Mod+-`  | Zoom in / out     | —         |
 | `Mod+0` / `Mod+Z`  | Reset zoom to 1.0 | —         |
+| Touchscreen drag   | Pan viewport      | on-canvas |
+| Touchscreen pinch  | Zoom              | on-canvas |
 
 </details>
 
@@ -199,7 +201,8 @@ window-search script that lets you search and jump to any open window.
 ### Everything else
 
 - New window placement: in viewport center (default), under cursor, or snapped adjacent to the focused window's cluster
-- Click-to-focus (default) or focus-follows-mouse (sloppy focus)
+- Click-to-focus (default), focus-follows-mouse (sloppy focus), or touch-to-focus
+- Touchscreen support: 1-finger canvas drag-panning and 2-finger anchor pinch-to-zoom
 - Session lock (swaylock), idle notify (swayidle/hypridle)
 - Screen capture: screencasting (OBS, Firefox, Discord) and screenshots, incl. built-in [canvas/DPI capture](docs/ipc.md#screenshots)
 - 40+ Wayland protocols

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ with no window there — useful for areas with pinned widgets.
 | Input                        | Action                                     |
 | ---------------------------- | ------------------------------------------ |
 | 4-finger swipe               | Jump to nearest window (natural direction) |
+| Touchscreen 3-finger swipe   | Jump to nearest window (natural direction) |
 | `Mod+Ctrl` + LMB drag        | Jump to nearest window (natural direction) |
 | `Mod` + arrow                | Jump to nearest window in direction        |
 | `Alt-Tab` / `Alt-Shift-Tab`  | Cycle windows (MRU)                        |
@@ -202,7 +203,7 @@ window-search script that lets you search and jump to any open window.
 
 - New window placement: in viewport center (default), under cursor, or snapped adjacent to the focused window's cluster
 - Click-to-focus (default), focus-follows-mouse (sloppy focus), or touch-to-focus
-- Touchscreen support: 1-finger canvas drag-panning and 2-finger anchor pinch-to-zoom
+- Touchscreen support: 1-finger canvas drag-panning, 2-finger anchor pinch-to-zoom, and 3-finger swipe navigation
 - Session lock (swaylock), idle notify (swayidle/hypridle)
 - Screen capture: screencasting (OBS, Firefox, Discord) and screenshots, incl. built-in [canvas/DPI capture](docs/ipc.md#screenshots)
 - 40+ Wayland protocols

--- a/config.reference.toml
+++ b/config.reference.toml
@@ -79,10 +79,11 @@
 
 [input.touch]
 # enable = true               # enable touchscreen support
-# enable_canvas_gestures = true # enable 1-finger drag pan and 2-finger pinch zoom on empty canvas
+# enable_canvas_gestures = true # enable 1-finger drag pan, 2-finger pinch zoom, and 3-finger swipe navigation
 # zoom_speed = 1.0            # touchscreen gesture zoom speed multiplier
 # pan_speed = 1.0             # touchscreen gesture pan speed multiplier
 # touch_to_focus = true       # focus and raise a window when touching it
+# swipe_threshold = 100.0     # distance (px) before 3-finger navigation swipe triggers
 
 [cursor]
 # theme = "none"             # XCURSOR_THEME; "none" = inherit from environment (e.g. "Adwaita")

--- a/config.reference.toml
+++ b/config.reference.toml
@@ -79,11 +79,6 @@
 
 [input.touch]
 # enable = true               # enable touchscreen support
-# enable_canvas_gestures = true # enable 1-finger drag pan, 2-finger pinch zoom, and 3-finger swipe navigation
-# zoom_speed = 1.0            # touchscreen gesture zoom speed multiplier
-# pan_speed = 1.0             # touchscreen gesture pan speed multiplier
-# touch_to_focus = true       # focus and raise a window when touching it
-# swipe_threshold = 100.0     # distance (px) before 3-finger navigation swipe triggers
 
 [cursor]
 # theme = "none"             # XCURSOR_THEME; "none" = inherit from environment (e.g. "Adwaita")
@@ -93,6 +88,7 @@
 [navigation]
 # trackpad_speed = 1.5        # trackpad (scroll/gestures) pan multiplier
 # mouse_speed = 1.0           # mouse (drag) pan multiplier (1.0 = direct)
+# touch_speed = 1.0           # touchscreen gesture pan speed multiplier
 # drift = 0.5                 # momentum coast: 0 = off, 0.5 = default, 1 = floatiest
 # animation_speed = 0.3       # camera lerp factor (higher = faster)
 # auto_navigate_on_close = true  # on close, pan to the newly focused window if off-screen
@@ -118,6 +114,7 @@
 
 [zoom]
 # step = 1.1                  # multiplier per keypress (1.1 = 10% per press)
+# touch_speed = 1.0           # touchscreen gesture zoom speed multiplier
 # fit_padding = 80.0          # viewport px padding for zoom-to-fit (screen space)
 # reset_on_new_window = true  # animate zoom to 1.0 when a new window is mapped
                               # (false = keep current zoom, pan only)

--- a/config.reference.toml
+++ b/config.reference.toml
@@ -77,6 +77,13 @@
 # accel_profile = "flat"      # "flat" or "adaptive"
 # natural_scroll = false      # reverse scroll direction
 
+[input.touch]
+# enable = true               # enable touchscreen support
+# enable_canvas_gestures = true # enable 1-finger drag pan and 2-finger pinch zoom on empty canvas
+# zoom_speed = 1.0            # touchscreen gesture zoom speed multiplier
+# pan_speed = 1.0             # touchscreen gesture pan speed multiplier
+# touch_to_focus = true       # focus and raise a window when touching it
+
 [cursor]
 # theme = "none"             # XCURSOR_THEME; "none" = inherit from environment (e.g. "Adwaita")
 # size = 0                    # XCURSOR_SIZE; 0 = inherit from environment (e.g. 24)

--- a/docs/config.md
+++ b/docs/config.md
@@ -190,36 +190,6 @@ Default: `true`
 
 enable touchscreen support
 
-### `enable_canvas_gestures`
-
-Default: `true`
-
-enable 1-finger drag pan, 2-finger pinch zoom, and 3-finger swipe navigation
-
-### `zoom_speed`
-
-Default: `1.0`
-
-touchscreen gesture zoom speed multiplier
-
-### `pan_speed`
-
-Default: `1.0`
-
-touchscreen gesture pan speed multiplier
-
-### `touch_to_focus`
-
-Default: `true`
-
-focus and raise a window when touching it
-
-### `swipe_threshold`
-
-Default: `100.0`
-
-distance (px) before 3-finger navigation swipe triggers
-
 ## `[cursor]`
 
 ### `theme`
@@ -253,6 +223,12 @@ trackpad (scroll/gestures) pan multiplier
 Default: `1.0`
 
 mouse (drag) pan multiplier (1.0 = direct)
+
+### `touch_speed`
+
+Default: `1.0`
+
+touchscreen gesture pan speed multiplier
 
 ### `drift`
 
@@ -335,6 +311,12 @@ cursor edge-pan activation zone (px) — kept small so it doesn't trigger by acc
 Default: `1.1`
 
 multiplier per keypress (1.1 = 10% per press)
+
+### `touch_speed`
+
+Default: `1.0`
+
+touchscreen gesture zoom speed multiplier
 
 ### `fit_padding`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -182,6 +182,38 @@ Default: `false`
 
 reverse scroll direction
 
+## `[input.touch]`
+
+### `enable`
+
+Default: `true`
+
+enable touchscreen support
+
+### `enable_canvas_gestures`
+
+Default: `true`
+
+enable 1-finger drag pan and 2-finger pinch zoom on empty canvas
+
+### `zoom_speed`
+
+Default: `1.0`
+
+touchscreen gesture zoom speed multiplier
+
+### `pan_speed`
+
+Default: `1.0`
+
+touchscreen gesture pan speed multiplier
+
+### `touch_to_focus`
+
+Default: `true`
+
+focus and raise a window when touching it
+
 ## `[cursor]`
 
 ### `theme`

--- a/docs/config.md
+++ b/docs/config.md
@@ -194,7 +194,7 @@ enable touchscreen support
 
 Default: `true`
 
-enable 1-finger drag pan and 2-finger pinch zoom on empty canvas
+enable 1-finger drag pan, 2-finger pinch zoom, and 3-finger swipe navigation
 
 ### `zoom_speed`
 
@@ -213,6 +213,12 @@ touchscreen gesture pan speed multiplier
 Default: `true`
 
 focus and raise a window when touching it
+
+### `swipe_threshold`
+
+Default: `100.0`
+
+distance (px) before 3-finger navigation swipe triggers
 
 ## `[cursor]`
 

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,7 @@
 
       devShells.${system}.default = pkgs.mkShell {
         inputsFrom = [ self.packages.${system}.default ];
+        packages = [ pkgs.rustfmt ];
 
         LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibs;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -102,7 +102,7 @@
       };
 
       devShells.${system}.default = pkgs.mkShell {
-        inherit nativeBuildInputs buildInputs;
+        inputsFrom = [ self.packages.${system}.default ];
 
         LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibs;
       };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -520,6 +520,7 @@ impl Config {
                 zoom_speed: t.zoom_speed.unwrap_or(1.0),
                 pan_speed: t.pan_speed.unwrap_or(1.0),
                 touch_to_focus: t.touch_to_focus.unwrap_or(true),
+                swipe_threshold: t.swipe_threshold.unwrap_or(100.0),
             }
         };
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -95,6 +95,7 @@ pub struct Config {
     pub background: BackgroundConfig,
     pub trackpad: TrackpadSettings,
     pub mouse_device: MouseDeviceSettings,
+    pub touch: TouchSettings,
     pub gesture_thresholds: GestureThresholds,
     pub layout_independent: bool,
     pub keyboard_layout: KeyboardLayout,
@@ -511,6 +512,17 @@ impl Config {
             }
         };
 
+        let touch = {
+            let t = &raw.input.touch;
+            TouchSettings {
+                enable: t.enable.unwrap_or(true),
+                enable_canvas_gestures: t.enable_canvas_gestures.unwrap_or(true),
+                zoom_speed: t.zoom_speed.unwrap_or(1.0),
+                pan_speed: t.pan_speed.unwrap_or(1.0),
+                touch_to_focus: t.touch_to_focus.unwrap_or(true),
+            }
+        };
+
         let gesture_thresholds = GestureThresholds {
             swipe_distance: non_negative(
                 raw.gestures.swipe_threshold.unwrap_or(12.0),
@@ -732,6 +744,7 @@ impl Config {
             backend,
             trackpad,
             mouse_device,
+            touch,
             gesture_thresholds,
             layout_independent: raw.input.keyboard.layout_independent.unwrap_or(true),
             keyboard_layout,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,6 +47,8 @@ pub struct Config {
     pub trackpad_speed: f64,
     /// Multiplier for mouse drag pan (Mod+LMB or LMB on canvas). 1.0 = direct.
     pub mouse_speed: f64,
+    /// Multiplier for touchscreen pan gestures.
+    pub touch_speed: f64,
     /// Scroll momentum on a 0–1 scale: 0 = off, 0.5 = default, 1 = floatiest.
     pub drift: f64,
     /// Pixels per keyboard nudge (Mod+Shift+Arrow).
@@ -77,6 +79,8 @@ pub struct Config {
     pub cycle_hold: Modifiers,
     /// Zoom step multiplier per keypress. 1.1 = 10% per press.
     pub zoom_step: f64,
+    /// Touchscreen gesture zoom speed multiplier.
+    pub zoom_touch_speed: f64,
     /// Padding (viewport/screen pixels) around the bounding box for ZoomToFit.
     /// Screen-space so the gutter is consistent regardless of the resulting zoom.
     pub zoom_fit_padding: f64,
@@ -516,11 +520,6 @@ impl Config {
             let t = &raw.input.touch;
             TouchSettings {
                 enable: t.enable.unwrap_or(true),
-                enable_canvas_gestures: t.enable_canvas_gestures.unwrap_or(true),
-                zoom_speed: t.zoom_speed.unwrap_or(1.0),
-                pan_speed: t.pan_speed.unwrap_or(1.0),
-                touch_to_focus: t.touch_to_focus.unwrap_or(true),
-                swipe_threshold: t.swipe_threshold.unwrap_or(100.0),
             }
         };
 
@@ -610,6 +609,11 @@ impl Config {
             "navigation.mouse_speed",
             &mut errors,
         );
+        let touch_speed = non_negative(
+            raw.navigation.touch_speed.unwrap_or(1.0),
+            "navigation.touch_speed",
+            &mut errors,
+        );
         let drift = clamp_warn(
             raw.navigation.drift.unwrap_or(0.5),
             0.0,
@@ -672,6 +676,7 @@ impl Config {
             focus_follows_mouse: raw.focus_follows_mouse.unwrap_or(false),
             trackpad_speed,
             mouse_speed,
+            touch_speed,
             drift,
             nudge_step: non_negative(
                 raw.navigation.nudge_step.unwrap_or(20),
@@ -718,6 +723,11 @@ impl Config {
             auto_navigate_on_close: raw.navigation.auto_navigate_on_close.unwrap_or(true),
             cycle_hold,
             zoom_step: non_negative(raw.zoom.step.unwrap_or(1.1), "zoom.step", &mut errors),
+            zoom_touch_speed: non_negative(
+                raw.zoom.touch_speed.unwrap_or(1.0),
+                "zoom.touch_speed",
+                &mut errors,
+            ),
             zoom_fit_padding: non_negative(
                 raw.zoom.fit_padding.unwrap_or(80.0),
                 "zoom.fit_padding",

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -52,6 +52,17 @@ pub(super) struct InputConfig {
     pub keyboard: KeyboardConfig,
     pub trackpad: TrackpadConfig,
     pub mouse: MouseDeviceFileConfig,
+    pub touch: TouchDeviceFileConfig,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct TouchDeviceFileConfig {
+    pub enable: Option<bool>,
+    pub enable_canvas_gestures: Option<bool>,
+    pub zoom_speed: Option<f64>,
+    pub pan_speed: Option<f64>,
+    pub touch_to_focus: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -59,11 +59,6 @@ pub(super) struct InputConfig {
 #[serde(default, deny_unknown_fields)]
 pub(super) struct TouchDeviceFileConfig {
     pub enable: Option<bool>,
-    pub enable_canvas_gestures: Option<bool>,
-    pub zoom_speed: Option<f64>,
-    pub pan_speed: Option<f64>,
-    pub touch_to_focus: Option<bool>,
-    pub swipe_threshold: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -118,6 +113,7 @@ pub(super) struct NavigationConfig {
     pub pan_step: Option<f64>,
     pub trackpad_speed: Option<f64>,
     pub mouse_speed: Option<f64>,
+    pub touch_speed: Option<f64>,
     pub drift: Option<f64>,
     /// Renamed to `drift`; kept only so a stale value yields a migration error
     /// instead of failing the whole parse via `deny_unknown_fields`.
@@ -147,6 +143,7 @@ pub(super) struct ZoomConfig {
     pub fit_padding: Option<f64>,
     pub reset_on_new_window: Option<bool>,
     pub reset_on_activation: Option<bool>,
+    pub touch_speed: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -63,6 +63,7 @@ pub(super) struct TouchDeviceFileConfig {
     pub zoom_speed: Option<f64>,
     pub pan_speed: Option<f64>,
     pub touch_to_focus: Option<bool>,
+    pub swipe_threshold: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -373,6 +373,27 @@ impl Default for TrackpadSettings {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct TouchSettings {
+    pub enable: bool,
+    pub enable_canvas_gestures: bool,
+    pub zoom_speed: f64,
+    pub pan_speed: f64,
+    pub touch_to_focus: bool,
+}
+
+impl Default for TouchSettings {
+    fn default() -> Self {
+        Self {
+            enable: true,
+            enable_canvas_gestures: true,
+            zoom_speed: 1.0,
+            pan_speed: 1.0,
+            touch_to_focus: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct MouseDeviceSettings {
     pub accel_speed: f64,
     pub accel_profile: AccelProfile,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -375,23 +375,11 @@ impl Default for TrackpadSettings {
 #[derive(Clone, Debug, PartialEq)]
 pub struct TouchSettings {
     pub enable: bool,
-    pub enable_canvas_gestures: bool,
-    pub zoom_speed: f64,
-    pub pan_speed: f64,
-    pub touch_to_focus: bool,
-    pub swipe_threshold: f64,
 }
 
 impl Default for TouchSettings {
     fn default() -> Self {
-        Self {
-            enable: true,
-            enable_canvas_gestures: true,
-            zoom_speed: 1.0,
-            pan_speed: 1.0,
-            touch_to_focus: true,
-            swipe_threshold: 100.0,
-        }
+        Self { enable: true }
     }
 }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -379,6 +379,7 @@ pub struct TouchSettings {
     pub zoom_speed: f64,
     pub pan_speed: f64,
     pub touch_to_focus: bool,
+    pub swipe_threshold: f64,
 }
 
 impl Default for TouchSettings {
@@ -389,6 +390,7 @@ impl Default for TouchSettings {
             zoom_speed: 1.0,
             pan_speed: 1.0,
             touch_to_focus: true,
+            swipe_threshold: 100.0,
         }
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,6 +2,7 @@ mod actions;
 pub(crate) mod gestures;
 pub(crate) mod keyboard;
 mod pointer;
+pub(crate) mod touch;
 
 use smithay::{
     backend::input::{
@@ -181,6 +182,11 @@ impl DriftWm {
                     pointer.axis(self, frame);
                     pointer.frame(self);
                 }
+                InputEvent::TouchDown { event } => self.on_touch_down::<I>(event),
+                InputEvent::TouchMotion { event } => self.on_touch_motion::<I>(event),
+                InputEvent::TouchUp { event } => self.on_touch_up::<I>(event),
+                InputEvent::TouchCancel { event } => self.on_touch_cancel::<I>(event),
+                InputEvent::TouchFrame { event } => self.on_touch_frame::<I>(event),
                 _ => {}
             }
             return;
@@ -196,6 +202,8 @@ impl DriftWm {
                 | InputEvent::GestureSwipeBegin { .. }
                 | InputEvent::GesturePinchBegin { .. }
                 | InputEvent::GestureHoldBegin { .. }
+                | InputEvent::TouchDown { .. }
+                | InputEvent::TouchMotion { .. }
         ) {
             self.tap.taint();
         }
@@ -216,6 +224,11 @@ impl DriftWm {
             InputEvent::GesturePinchEnd { event } => self.on_gesture_pinch_end::<I>(event),
             InputEvent::GestureHoldBegin { event } => self.on_gesture_hold_begin::<I>(event),
             InputEvent::GestureHoldEnd { event } => self.on_gesture_hold_end::<I>(event),
+            InputEvent::TouchDown { event } => self.on_touch_down::<I>(event),
+            InputEvent::TouchMotion { event } => self.on_touch_motion::<I>(event),
+            InputEvent::TouchUp { event } => self.on_touch_up::<I>(event),
+            InputEvent::TouchCancel { event } => self.on_touch_cancel::<I>(event),
+            InputEvent::TouchFrame { event } => self.on_touch_frame::<I>(event),
             _ => {}
         }
     }

--- a/src/input/touch.rs
+++ b/src/input/touch.rs
@@ -1,15 +1,11 @@
-use std::collections::HashMap;
+use crate::state::{DriftWm, FocusTarget};
+use driftwm::canvas::{self, ScreenPos, screen_to_canvas};
 use smithay::{
-    backend::input::{
-        AbsolutePositionEvent, Event, InputBackend, TouchEvent, TouchSlot,
-    },
+    backend::input::{AbsolutePositionEvent, Event, InputBackend, TouchEvent, TouchSlot},
     input::touch::{DownEvent, MotionEvent, UpEvent},
     utils::{Logical, Point, SERIAL_COUNTER},
 };
-use crate::state::{DriftWm, FocusTarget};
-use driftwm::canvas::{self, ScreenPos, screen_to_canvas};
-use driftwm::config::Action;
-use crate::input::gestures::direction_from_vector;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct ActiveTouchPoint {
@@ -26,7 +22,6 @@ pub enum TouchGestureMode {
     None,
     CanvasPan,
     CanvasPinch,
-    CanvasSwipe,
 }
 
 #[derive(Debug, Clone)]
@@ -34,8 +29,6 @@ pub struct TouchState {
     pub active_touches: HashMap<TouchSlot, ActiveTouchPoint>,
     pub gesture_active: TouchGestureMode,
     pub initial_zoom: f64,
-    pub swipe_start_pos: Point<f64, Logical>,
-    pub swipe_triggered: bool,
 }
 
 impl TouchState {
@@ -44,8 +37,6 @@ impl TouchState {
             active_touches: HashMap::new(),
             gesture_active: TouchGestureMode::None,
             initial_zoom: 1.0,
-            swipe_start_pos: Point::from((0.0, 0.0)),
-            swipe_triggered: false,
         }
     }
 }
@@ -114,13 +105,11 @@ impl DriftWm {
         let under = self.pointer_focus_under(screen_pos, canvas_pos);
 
         if let Some((ref target, ref origin)) = under {
-            // Touch landed on a window or layer surface
-            if self.config.touch.touch_to_focus {
-                if let Some(window) = self.window_for_surface(&target.0) {
-                    self.raise_and_focus(&window, serial);
-                } else {
-                    self.set_window_focus(Some(target.clone()), serial);
-                }
+            // Touch landed on a window or layer surface: unconditionally focus + raise
+            if let Some(window) = self.window_for_surface(&target.0) {
+                self.raise_and_focus(&window, serial);
+            } else {
+                self.set_window_focus(Some(target.clone()), serial);
             }
 
             // Forward to Wayland client
@@ -134,11 +123,8 @@ impl DriftWm {
                 touch_handle.down(self, Some((target.clone(), *origin)), &raw_event);
             }
         } else {
-            // Touch landed on empty background. Check gestures.
-            if self.config.touch.enable_canvas_gestures {
-                // Cancel existing animations (stop slide)
-                self.cancel_animations();
-            }
+            // Touch landed on empty background. Cancel existing animations (stop slide)
+            self.cancel_animations();
         }
 
         // Record touch state
@@ -155,29 +141,24 @@ impl DriftWm {
         );
 
         // Update/Transition gesture states based on active count
-        if self.config.touch.enable_canvas_gestures {
-            let active_count = self.touch_state.active_touches.len();
-            let any_on_window = self.touch_state.active_touches.values().any(|tp| tp.focus.is_some());
+        let active_count = self.touch_state.active_touches.len();
+        let any_on_window = self
+            .touch_state
+            .active_touches
+            .values()
+            .any(|tp| tp.focus.is_some());
 
-            if !any_on_window {
-                if active_count == 3 {
-                    let sum_screen = self.touch_state.active_touches.values()
-                        .map(|tp| tp.last_screen_pos)
-                        .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
-                    self.touch_state.swipe_start_pos = Point::from((sum_screen.x / 4.0, sum_screen.y / 4.0));
-                    self.touch_state.swipe_triggered = false;
-                    self.touch_state.gesture_active = TouchGestureMode::CanvasSwipe;
-                } else if active_count == 2 {
-                    self.touch_state.gesture_active = TouchGestureMode::CanvasPinch;
-                    self.touch_state.initial_zoom = self.zoom();
-                } else if active_count == 1 {
-                    self.touch_state.gesture_active = TouchGestureMode::CanvasPan;
-                } else {
-                    self.touch_state.gesture_active = TouchGestureMode::None;
-                }
+        if !any_on_window {
+            if active_count == 2 {
+                self.touch_state.gesture_active = TouchGestureMode::CanvasPinch;
+                self.touch_state.initial_zoom = self.zoom();
+            } else if active_count == 1 {
+                self.touch_state.gesture_active = TouchGestureMode::CanvasPan;
             } else {
                 self.touch_state.gesture_active = TouchGestureMode::None;
             }
+        } else {
+            self.touch_state.gesture_active = TouchGestureMode::None;
         }
     }
 
@@ -229,7 +210,7 @@ impl DriftWm {
             TouchGestureMode::CanvasPan => {
                 let active_count = self.touch_state.active_touches.len() as f64;
                 let delta = screen_pos - touch_point.last_screen_pos;
-                let pan_speed = self.config.touch.pan_speed;
+                let pan_speed = self.config.touch_speed;
                 let zoom = self.zoom();
                 let mut camera = self.camera();
                 camera.x -= (delta.x * pan_speed) / (zoom * active_count);
@@ -238,32 +219,49 @@ impl DriftWm {
                 self.mark_all_dirty();
             }
             TouchGestureMode::CanvasPinch => {
-                let active_touches: Vec<&ActiveTouchPoint> = self.touch_state.active_touches.values().collect();
+                let active_touches: Vec<&ActiveTouchPoint> =
+                    self.touch_state.active_touches.values().collect();
                 let count = active_touches.len() as f64;
                 if count >= 2.0 {
                     // Current midpoint (screen)
-                    let sum_screen_curr = active_touches.iter()
-                        .map(|tp| if tp.slot == slot { screen_pos } else { tp.last_screen_pos })
+                    let sum_screen_curr = active_touches
+                        .iter()
+                        .map(|tp| {
+                            if tp.slot == slot {
+                                screen_pos
+                            } else {
+                                tp.last_screen_pos
+                            }
+                        })
                         .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
-                    let midpoint_screen_curr = Point::from((sum_screen_curr.x / count, sum_screen_curr.y / count));
+                    let midpoint_screen_curr =
+                        Point::from((sum_screen_curr.x / count, sum_screen_curr.y / count));
 
                     // Start midpoint (screen)
-                    let sum_screen_start = active_touches.iter()
+                    let sum_screen_start = active_touches
+                        .iter()
                         .map(|tp| tp.start_screen_pos)
                         .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
-                    let midpoint_screen_start = Point::from((sum_screen_start.x / count, sum_screen_start.y / count));
+                    let midpoint_screen_start =
+                        Point::from((sum_screen_start.x / count, sum_screen_start.y / count));
 
                     // Current average distance to current midpoint
-                    let sum_dist_curr = active_touches.iter()
+                    let sum_dist_curr = active_touches
+                        .iter()
                         .map(|tp| {
-                            let p = if tp.slot == slot { screen_pos } else { tp.last_screen_pos };
+                            let p = if tp.slot == slot {
+                                screen_pos
+                            } else {
+                                tp.last_screen_pos
+                            };
                             distance(p, midpoint_screen_curr)
                         })
                         .sum::<f64>();
                     let avg_dist_curr = sum_dist_curr / count;
 
                     // Start average distance to start midpoint
-                    let sum_dist_start = active_touches.iter()
+                    let sum_dist_start = active_touches
+                        .iter()
                         .map(|tp| distance(tp.start_screen_pos, midpoint_screen_start))
                         .sum::<f64>();
                     let avg_dist_start = sum_dist_start / count;
@@ -271,39 +269,28 @@ impl DriftWm {
                     if avg_dist_start > 0.0 {
                         let scale = avg_dist_curr / avg_dist_start;
                         let initial_zoom = self.touch_state.initial_zoom;
-                        let zoom_speed = self.config.touch.zoom_speed;
+                        let zoom_speed = self.config.zoom_touch_speed;
                         let min_zoom = self.min_zoom();
-                        
+
                         let mut new_zoom = initial_zoom * (1.0 + (scale - 1.0) * zoom_speed);
                         new_zoom = new_zoom.clamp(min_zoom, canvas::MAX_ZOOM);
 
                         // Start midpoint (canvas)
-                        let sum_canvas_start = active_touches.iter()
+                        let sum_canvas_start = active_touches
+                            .iter()
                             .map(|tp| tp.start_canvas_pos)
                             .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
-                        let midpoint_canvas_start = Point::from((sum_canvas_start.x / count, sum_canvas_start.y / count));
+                        let midpoint_canvas_start =
+                            Point::from((sum_canvas_start.x / count, sum_canvas_start.y / count));
 
-                        let new_camera = canvas::zoom_anchor_camera(midpoint_canvas_start, midpoint_screen_curr, new_zoom);
+                        let new_camera = canvas::zoom_anchor_camera(
+                            midpoint_canvas_start,
+                            midpoint_screen_curr,
+                            new_zoom,
+                        );
                         self.set_zoom(new_zoom);
                         self.set_camera(new_camera);
                         self.mark_all_dirty();
-                    }
-                }
-            }
-            TouchGestureMode::CanvasSwipe => {
-                if !self.touch_state.swipe_triggered {
-                    let sum_screen = self.touch_state.active_touches.values()
-                        .map(|tp| if tp.slot == slot { screen_pos } else { tp.last_screen_pos })
-                        .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
-                    let count = self.touch_state.active_touches.len() as f64;
-                    if count > 0.0 {
-                        let current_avg = Point::from((sum_screen.x / count, sum_screen.y / count));
-                        let dist = distance(current_avg, self.touch_state.swipe_start_pos);
-                        if dist >= self.config.touch.swipe_threshold {
-                            let dir = direction_from_vector(self.touch_state.swipe_start_pos - current_avg);
-                            self.execute_action(&Action::CenterNearest(dir));
-                            self.touch_state.swipe_triggered = true;
-                        }
                     }
                 }
             }
@@ -343,11 +330,7 @@ impl DriftWm {
         // 1. Locked session handling
         if !matches!(self.session_lock, crate::state::SessionLock::Unlocked) {
             let touch_handle = self.seat.get_touch().unwrap();
-            let raw_event = UpEvent {
-                slot,
-                serial,
-                time,
-            };
+            let raw_event = UpEvent { slot, serial, time };
             touch_handle.up(self, &raw_event);
             touch_handle.frame(self);
             return;
@@ -360,11 +343,7 @@ impl DriftWm {
             }
         } else if let Some(ref _focus) = touch_point.focus {
             if let Some(touch_handle) = self.seat.get_touch() {
-                let raw_event = UpEvent {
-                    slot,
-                    serial,
-                    time,
-                };
+                let raw_event = UpEvent { slot, serial, time };
                 touch_handle.up(self, &raw_event);
             }
         }

--- a/src/input/touch.rs
+++ b/src/input/touch.rs
@@ -8,6 +8,8 @@ use smithay::{
 };
 use crate::state::{DriftWm, FocusTarget};
 use driftwm::canvas::{self, ScreenPos, screen_to_canvas};
+use driftwm::config::Action;
+use crate::input::gestures::direction_from_vector;
 
 #[derive(Debug, Clone)]
 pub struct ActiveTouchPoint {
@@ -24,6 +26,7 @@ pub enum TouchGestureMode {
     None,
     CanvasPan,
     CanvasPinch,
+    CanvasSwipe,
 }
 
 #[derive(Debug, Clone)]
@@ -31,6 +34,8 @@ pub struct TouchState {
     pub active_touches: HashMap<TouchSlot, ActiveTouchPoint>,
     pub gesture_active: TouchGestureMode,
     pub initial_zoom: f64,
+    pub swipe_start_pos: Point<f64, Logical>,
+    pub swipe_triggered: bool,
 }
 
 impl TouchState {
@@ -39,6 +44,8 @@ impl TouchState {
             active_touches: HashMap::new(),
             gesture_active: TouchGestureMode::None,
             initial_zoom: 1.0,
+            swipe_start_pos: Point::from((0.0, 0.0)),
+            swipe_triggered: false,
         }
     }
 }
@@ -131,14 +138,6 @@ impl DriftWm {
             if self.config.touch.enable_canvas_gestures {
                 // Cancel existing animations (stop slide)
                 self.cancel_animations();
-
-                let active_count = self.touch_state.active_touches.len();
-                if active_count == 0 {
-                    self.touch_state.gesture_active = TouchGestureMode::CanvasPan;
-                } else if active_count == 1 {
-                    self.touch_state.gesture_active = TouchGestureMode::CanvasPinch;
-                    self.touch_state.initial_zoom = self.zoom();
-                }
             }
         }
 
@@ -151,9 +150,62 @@ impl DriftWm {
                 last_screen_pos: screen_pos,
                 start_canvas_pos: canvas_pos,
                 last_canvas_pos: canvas_pos,
-                focus: under,
+                focus: under.clone(),
             },
         );
+
+        // Update/Transition gesture states based on active count
+        if self.config.touch.enable_canvas_gestures {
+            let active_count = self.touch_state.active_touches.len();
+            if active_count == 3 {
+                // Determine starting average of the 3 touches
+                let sum_screen = self.touch_state.active_touches.values()
+                    .map(|tp| tp.last_screen_pos)
+                    .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
+                self.touch_state.swipe_start_pos = Point::from((sum_screen.x / 3.0, sum_screen.y / 3.0));
+                self.touch_state.swipe_triggered = false;
+                self.touch_state.gesture_active = TouchGestureMode::CanvasSwipe;
+
+                // Cancel client touches
+                let mut needs_cancel = false;
+                for tp in self.touch_state.active_touches.values() {
+                    if tp.focus.is_some() {
+                        needs_cancel = true;
+                        break;
+                    }
+                }
+                if needs_cancel {
+                    if let Some(touch_handle) = self.seat.get_touch() {
+                        touch_handle.cancel(self);
+                    }
+                    for tp in self.touch_state.active_touches.values_mut() {
+                        tp.focus = None;
+                    }
+                }
+            } else if active_count == 2 {
+                self.touch_state.gesture_active = TouchGestureMode::CanvasPinch;
+                self.touch_state.initial_zoom = self.zoom();
+
+                // Cancel client touches
+                let mut needs_cancel = false;
+                for tp in self.touch_state.active_touches.values() {
+                    if tp.focus.is_some() {
+                        needs_cancel = true;
+                        break;
+                    }
+                }
+                if needs_cancel {
+                    if let Some(touch_handle) = self.seat.get_touch() {
+                        touch_handle.cancel(self);
+                    }
+                    for tp in self.touch_state.active_touches.values_mut() {
+                        tp.focus = None;
+                    }
+                }
+            } else if active_count == 1 && under.is_none() {
+                self.touch_state.gesture_active = TouchGestureMode::CanvasPan;
+            }
+        }
     }
 
     pub fn on_touch_motion<I: InputBackend>(&mut self, event: I::TouchMotionEvent) {
@@ -243,6 +295,23 @@ impl DriftWm {
                         self.set_zoom(new_zoom);
                         self.set_camera(new_camera);
                         self.mark_all_dirty();
+                    }
+                }
+            }
+            TouchGestureMode::CanvasSwipe => {
+                if !self.touch_state.swipe_triggered {
+                    let sum_screen = self.touch_state.active_touches.values()
+                        .map(|tp| if tp.slot == slot { screen_pos } else { tp.last_screen_pos })
+                        .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
+                    let count = self.touch_state.active_touches.len() as f64;
+                    if count > 0.0 {
+                        let current_avg = Point::from((sum_screen.x / count, sum_screen.y / count));
+                        let dist = distance(current_avg, self.touch_state.swipe_start_pos);
+                        if dist >= self.config.touch.swipe_threshold {
+                            let dir = direction_from_vector(current_avg - self.touch_state.swipe_start_pos);
+                            self.execute_action(&Action::CenterNearest(dir));
+                            self.touch_state.swipe_triggered = true;
+                        }
                     }
                 }
             }

--- a/src/input/touch.rs
+++ b/src/input/touch.rs
@@ -157,53 +157,26 @@ impl DriftWm {
         // Update/Transition gesture states based on active count
         if self.config.touch.enable_canvas_gestures {
             let active_count = self.touch_state.active_touches.len();
-            if active_count == 3 {
-                // Determine starting average of the 3 touches
-                let sum_screen = self.touch_state.active_touches.values()
-                    .map(|tp| tp.last_screen_pos)
-                    .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
-                self.touch_state.swipe_start_pos = Point::from((sum_screen.x / 3.0, sum_screen.y / 3.0));
-                self.touch_state.swipe_triggered = false;
-                self.touch_state.gesture_active = TouchGestureMode::CanvasSwipe;
+            let any_on_window = self.touch_state.active_touches.values().any(|tp| tp.focus.is_some());
 
-                // Cancel client touches
-                let mut needs_cancel = false;
-                for tp in self.touch_state.active_touches.values() {
-                    if tp.focus.is_some() {
-                        needs_cancel = true;
-                        break;
-                    }
+            if !any_on_window {
+                if active_count == 3 {
+                    let sum_screen = self.touch_state.active_touches.values()
+                        .map(|tp| tp.last_screen_pos)
+                        .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
+                    self.touch_state.swipe_start_pos = Point::from((sum_screen.x / 4.0, sum_screen.y / 4.0));
+                    self.touch_state.swipe_triggered = false;
+                    self.touch_state.gesture_active = TouchGestureMode::CanvasSwipe;
+                } else if active_count == 2 {
+                    self.touch_state.gesture_active = TouchGestureMode::CanvasPinch;
+                    self.touch_state.initial_zoom = self.zoom();
+                } else if active_count == 1 {
+                    self.touch_state.gesture_active = TouchGestureMode::CanvasPan;
+                } else {
+                    self.touch_state.gesture_active = TouchGestureMode::None;
                 }
-                if needs_cancel {
-                    if let Some(touch_handle) = self.seat.get_touch() {
-                        touch_handle.cancel(self);
-                    }
-                    for tp in self.touch_state.active_touches.values_mut() {
-                        tp.focus = None;
-                    }
-                }
-            } else if active_count == 2 {
-                self.touch_state.gesture_active = TouchGestureMode::CanvasPinch;
-                self.touch_state.initial_zoom = self.zoom();
-
-                // Cancel client touches
-                let mut needs_cancel = false;
-                for tp in self.touch_state.active_touches.values() {
-                    if tp.focus.is_some() {
-                        needs_cancel = true;
-                        break;
-                    }
-                }
-                if needs_cancel {
-                    if let Some(touch_handle) = self.seat.get_touch() {
-                        touch_handle.cancel(self);
-                    }
-                    for tp in self.touch_state.active_touches.values_mut() {
-                        tp.focus = None;
-                    }
-                }
-            } else if active_count == 1 && under.is_none() {
-                self.touch_state.gesture_active = TouchGestureMode::CanvasPan;
+            } else {
+                self.touch_state.gesture_active = TouchGestureMode::None;
             }
         }
     }
@@ -254,30 +227,49 @@ impl DriftWm {
         // 2. Unlocked session handling
         match self.touch_state.gesture_active {
             TouchGestureMode::CanvasPan => {
+                let active_count = self.touch_state.active_touches.len() as f64;
                 let delta = screen_pos - touch_point.last_screen_pos;
                 let pan_speed = self.config.touch.pan_speed;
                 let zoom = self.zoom();
                 let mut camera = self.camera();
-                camera.x -= (delta.x * pan_speed) / zoom;
-                camera.y -= (delta.y * pan_speed) / zoom;
+                camera.x -= (delta.x * pan_speed) / (zoom * active_count);
+                camera.y -= (delta.y * pan_speed) / (zoom * active_count);
                 self.set_camera(camera);
                 self.mark_all_dirty();
             }
             TouchGestureMode::CanvasPinch => {
-                let slots: Vec<TouchSlot> = self.touch_state.active_touches.keys().copied().collect();
-                if slots.len() >= 2 {
-                    let s1 = slots[0];
-                    let s2 = slots[1];
-                    let p1_start = self.touch_state.active_touches[&s1].start_screen_pos;
-                    let p2_start = self.touch_state.active_touches[&s2].start_screen_pos;
-                    let p1_curr = if s1 == slot { screen_pos } else { self.touch_state.active_touches[&s1].last_screen_pos };
-                    let p2_curr = if s2 == slot { screen_pos } else { self.touch_state.active_touches[&s2].last_screen_pos };
+                let active_touches: Vec<&ActiveTouchPoint> = self.touch_state.active_touches.values().collect();
+                let count = active_touches.len() as f64;
+                if count >= 2.0 {
+                    // Current midpoint (screen)
+                    let sum_screen_curr = active_touches.iter()
+                        .map(|tp| if tp.slot == slot { screen_pos } else { tp.last_screen_pos })
+                        .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
+                    let midpoint_screen_curr = Point::from((sum_screen_curr.x / count, sum_screen_curr.y / count));
 
-                    let start_dist = distance(p1_start, p2_start);
-                    let curr_dist = distance(p1_curr, p2_curr);
+                    // Start midpoint (screen)
+                    let sum_screen_start = active_touches.iter()
+                        .map(|tp| tp.start_screen_pos)
+                        .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
+                    let midpoint_screen_start = Point::from((sum_screen_start.x / count, sum_screen_start.y / count));
 
-                    if start_dist > 0.0 {
-                        let scale = curr_dist / start_dist;
+                    // Current average distance to current midpoint
+                    let sum_dist_curr = active_touches.iter()
+                        .map(|tp| {
+                            let p = if tp.slot == slot { screen_pos } else { tp.last_screen_pos };
+                            distance(p, midpoint_screen_curr)
+                        })
+                        .sum::<f64>();
+                    let avg_dist_curr = sum_dist_curr / count;
+
+                    // Start average distance to start midpoint
+                    let sum_dist_start = active_touches.iter()
+                        .map(|tp| distance(tp.start_screen_pos, midpoint_screen_start))
+                        .sum::<f64>();
+                    let avg_dist_start = sum_dist_start / count;
+
+                    if avg_dist_start > 0.0 {
+                        let scale = avg_dist_curr / avg_dist_start;
                         let initial_zoom = self.touch_state.initial_zoom;
                         let zoom_speed = self.config.touch.zoom_speed;
                         let min_zoom = self.min_zoom();
@@ -285,13 +277,13 @@ impl DriftWm {
                         let mut new_zoom = initial_zoom * (1.0 + (scale - 1.0) * zoom_speed);
                         new_zoom = new_zoom.clamp(min_zoom, canvas::MAX_ZOOM);
 
-                        let sum_screen = p1_curr + p2_curr;
-                        let midpoint_screen = Point::from((sum_screen.x / 2.0, sum_screen.y / 2.0));
+                        // Start midpoint (canvas)
+                        let sum_canvas_start = active_touches.iter()
+                            .map(|tp| tp.start_canvas_pos)
+                            .fold(Point::from((0.0, 0.0)), |acc, p| acc + p);
+                        let midpoint_canvas_start = Point::from((sum_canvas_start.x / count, sum_canvas_start.y / count));
 
-                        let sum_canvas = self.touch_state.active_touches[&s1].start_canvas_pos + self.touch_state.active_touches[&s2].start_canvas_pos;
-                        let midpoint_canvas_start = Point::from((sum_canvas.x / 2.0, sum_canvas.y / 2.0));
-
-                        let new_camera = canvas::zoom_anchor_camera(midpoint_canvas_start, midpoint_screen, new_zoom);
+                        let new_camera = canvas::zoom_anchor_camera(midpoint_canvas_start, midpoint_screen_curr, new_zoom);
                         self.set_zoom(new_zoom);
                         self.set_camera(new_camera);
                         self.mark_all_dirty();
@@ -308,7 +300,7 @@ impl DriftWm {
                         let current_avg = Point::from((sum_screen.x / count, sum_screen.y / count));
                         let dist = distance(current_avg, self.touch_state.swipe_start_pos);
                         if dist >= self.config.touch.swipe_threshold {
-                            let dir = direction_from_vector(current_avg - self.touch_state.swipe_start_pos);
+                            let dir = direction_from_vector(self.touch_state.swipe_start_pos - current_avg);
                             self.execute_action(&Action::CenterNearest(dir));
                             self.touch_state.swipe_triggered = true;
                         }

--- a/src/input/touch.rs
+++ b/src/input/touch.rs
@@ -1,0 +1,325 @@
+use std::collections::HashMap;
+use smithay::{
+    backend::input::{
+        AbsolutePositionEvent, Event, InputBackend, TouchEvent, TouchSlot,
+    },
+    input::touch::{DownEvent, MotionEvent, UpEvent},
+    utils::{Logical, Point, SERIAL_COUNTER},
+};
+use crate::state::{DriftWm, FocusTarget};
+use driftwm::canvas::{self, ScreenPos, screen_to_canvas};
+
+#[derive(Debug, Clone)]
+pub struct ActiveTouchPoint {
+    pub slot: TouchSlot,
+    pub start_screen_pos: Point<f64, Logical>,
+    pub last_screen_pos: Point<f64, Logical>,
+    pub start_canvas_pos: Point<f64, Logical>,
+    pub last_canvas_pos: Point<f64, Logical>,
+    pub focus: Option<(FocusTarget, Point<f64, Logical>)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TouchGestureMode {
+    None,
+    CanvasPan,
+    CanvasPinch,
+}
+
+#[derive(Debug, Clone)]
+pub struct TouchState {
+    pub active_touches: HashMap<TouchSlot, ActiveTouchPoint>,
+    pub gesture_active: TouchGestureMode,
+    pub initial_zoom: f64,
+}
+
+impl TouchState {
+    pub fn new() -> Self {
+        Self {
+            active_touches: HashMap::new(),
+            gesture_active: TouchGestureMode::None,
+            initial_zoom: 1.0,
+        }
+    }
+}
+
+fn distance(p1: Point<f64, Logical>, p2: Point<f64, Logical>) -> f64 {
+    let dx = p1.x - p2.x;
+    let dy = p1.y - p2.y;
+    (dx * dx + dy * dy).sqrt()
+}
+
+impl DriftWm {
+    pub fn on_touch_down<I: InputBackend>(&mut self, event: I::TouchDownEvent) {
+        if !self.config.touch.enable {
+            return;
+        }
+        let output = match self.active_output() {
+            Some(o) => o,
+            None => return,
+        };
+        let Some(output_geo) = self.space.output_geometry(&output) else {
+            return;
+        };
+
+        let screen_pos = event.position_transformed(output_geo.size);
+        let canvas_pos = screen_to_canvas(ScreenPos(screen_pos), self.camera(), self.zoom()).0;
+        let slot = event.slot();
+        let time = Event::time_msec(&event);
+        let serial = SERIAL_COUNTER.next_serial();
+
+        // 1. Locked session handling
+        if !matches!(self.session_lock, crate::state::SessionLock::Unlocked) {
+            let Some(ls) = self.lock_surfaces.get(&output) else {
+                return;
+            };
+            let focus = FocusTarget(ls.wl_surface().clone());
+            let touch_handle = self.seat.get_touch().unwrap();
+            let raw_event = DownEvent {
+                slot,
+                location: screen_pos,
+                serial,
+                time,
+            };
+            touch_handle.down(
+                self,
+                Some((focus.clone(), Point::from((0.0, 0.0)))),
+                &raw_event,
+            );
+            touch_handle.frame(self);
+
+            // Record active touch point
+            self.touch_state.active_touches.insert(
+                slot,
+                ActiveTouchPoint {
+                    slot,
+                    start_screen_pos: screen_pos,
+                    last_screen_pos: screen_pos,
+                    start_canvas_pos: screen_pos,
+                    last_canvas_pos: screen_pos,
+                    focus: Some((focus, Point::from((0.0, 0.0)))),
+                },
+            );
+            return;
+        }
+
+        // 2. Unlocked session handling
+        let under = self.pointer_focus_under(screen_pos, canvas_pos);
+
+        if let Some((ref target, ref origin)) = under {
+            // Touch landed on a window or layer surface
+            if self.config.touch.touch_to_focus {
+                if let Some(window) = self.window_for_surface(&target.0) {
+                    self.raise_and_focus(&window, serial);
+                } else {
+                    self.set_window_focus(Some(target.clone()), serial);
+                }
+            }
+
+            // Forward to Wayland client
+            if let Some(touch_handle) = self.seat.get_touch() {
+                let raw_event = DownEvent {
+                    slot,
+                    location: canvas_pos,
+                    serial,
+                    time,
+                };
+                touch_handle.down(self, Some((target.clone(), *origin)), &raw_event);
+            }
+        } else {
+            // Touch landed on empty background. Check gestures.
+            if self.config.touch.enable_canvas_gestures {
+                // Cancel existing animations (stop slide)
+                self.cancel_animations();
+
+                let active_count = self.touch_state.active_touches.len();
+                if active_count == 0 {
+                    self.touch_state.gesture_active = TouchGestureMode::CanvasPan;
+                } else if active_count == 1 {
+                    self.touch_state.gesture_active = TouchGestureMode::CanvasPinch;
+                    self.touch_state.initial_zoom = self.zoom();
+                }
+            }
+        }
+
+        // Record touch state
+        self.touch_state.active_touches.insert(
+            slot,
+            ActiveTouchPoint {
+                slot,
+                start_screen_pos: screen_pos,
+                last_screen_pos: screen_pos,
+                start_canvas_pos: canvas_pos,
+                last_canvas_pos: canvas_pos,
+                focus: under,
+            },
+        );
+    }
+
+    pub fn on_touch_motion<I: InputBackend>(&mut self, event: I::TouchMotionEvent) {
+        if !self.config.touch.enable {
+            return;
+        }
+        let output = match self.active_output() {
+            Some(o) => o,
+            None => return,
+        };
+        let Some(output_geo) = self.space.output_geometry(&output) else {
+            return;
+        };
+
+        let screen_pos = event.position_transformed(output_geo.size);
+        let canvas_pos = screen_to_canvas(ScreenPos(screen_pos), self.camera(), self.zoom()).0;
+        let slot = event.slot();
+        let time = Event::time_msec(&event);
+
+        // Retrieve recorded touch point
+        let Some(touch_point) = self.touch_state.active_touches.get(&slot).cloned() else {
+            return;
+        };
+
+        // 1. Locked session handling
+        if !matches!(self.session_lock, crate::state::SessionLock::Unlocked) {
+            if let Some(ref focus) = touch_point.focus {
+                let touch_handle = self.seat.get_touch().unwrap();
+                let raw_event = MotionEvent {
+                    slot,
+                    location: screen_pos,
+                    time,
+                };
+                touch_handle.motion(self, Some((focus.0.clone(), focus.1)), &raw_event);
+                touch_handle.frame(self);
+            }
+
+            // Update touch point coordinates
+            if let Some(tp) = self.touch_state.active_touches.get_mut(&slot) {
+                tp.last_screen_pos = screen_pos;
+                tp.last_canvas_pos = screen_pos;
+            }
+            return;
+        }
+
+        // 2. Unlocked session handling
+        match self.touch_state.gesture_active {
+            TouchGestureMode::CanvasPan => {
+                let delta = screen_pos - touch_point.last_screen_pos;
+                let pan_speed = self.config.touch.pan_speed;
+                let zoom = self.zoom();
+                let mut camera = self.camera();
+                camera.x -= (delta.x * pan_speed) / zoom;
+                camera.y -= (delta.y * pan_speed) / zoom;
+                self.set_camera(camera);
+                self.mark_all_dirty();
+            }
+            TouchGestureMode::CanvasPinch => {
+                let slots: Vec<TouchSlot> = self.touch_state.active_touches.keys().copied().collect();
+                if slots.len() >= 2 {
+                    let s1 = slots[0];
+                    let s2 = slots[1];
+                    let p1_start = self.touch_state.active_touches[&s1].start_screen_pos;
+                    let p2_start = self.touch_state.active_touches[&s2].start_screen_pos;
+                    let p1_curr = if s1 == slot { screen_pos } else { self.touch_state.active_touches[&s1].last_screen_pos };
+                    let p2_curr = if s2 == slot { screen_pos } else { self.touch_state.active_touches[&s2].last_screen_pos };
+
+                    let start_dist = distance(p1_start, p2_start);
+                    let curr_dist = distance(p1_curr, p2_curr);
+
+                    if start_dist > 0.0 {
+                        let scale = curr_dist / start_dist;
+                        let initial_zoom = self.touch_state.initial_zoom;
+                        let zoom_speed = self.config.touch.zoom_speed;
+                        let min_zoom = self.min_zoom();
+                        
+                        let mut new_zoom = initial_zoom * (1.0 + (scale - 1.0) * zoom_speed);
+                        new_zoom = new_zoom.clamp(min_zoom, canvas::MAX_ZOOM);
+
+                        let sum_screen = p1_curr + p2_curr;
+                        let midpoint_screen = Point::from((sum_screen.x / 2.0, sum_screen.y / 2.0));
+
+                        let sum_canvas = self.touch_state.active_touches[&s1].start_canvas_pos + self.touch_state.active_touches[&s2].start_canvas_pos;
+                        let midpoint_canvas_start = Point::from((sum_canvas.x / 2.0, sum_canvas.y / 2.0));
+
+                        let new_camera = canvas::zoom_anchor_camera(midpoint_canvas_start, midpoint_screen, new_zoom);
+                        self.set_zoom(new_zoom);
+                        self.set_camera(new_camera);
+                        self.mark_all_dirty();
+                    }
+                }
+            }
+            TouchGestureMode::None => {
+                if let Some(ref focus) = touch_point.focus {
+                    if let Some(touch_handle) = self.seat.get_touch() {
+                        let raw_event = MotionEvent {
+                            slot,
+                            location: canvas_pos,
+                            time,
+                        };
+                        touch_handle.motion(self, Some((focus.0.clone(), focus.1)), &raw_event);
+                    }
+                }
+            }
+        }
+
+        // Update recorded touch point coordinates
+        if let Some(tp) = self.touch_state.active_touches.get_mut(&slot) {
+            tp.last_screen_pos = screen_pos;
+            tp.last_canvas_pos = canvas_pos;
+        }
+    }
+
+    pub fn on_touch_up<I: InputBackend>(&mut self, event: I::TouchUpEvent) {
+        if !self.config.touch.enable {
+            return;
+        }
+        let slot = event.slot();
+        let time = Event::time_msec(&event);
+        let serial = SERIAL_COUNTER.next_serial();
+
+        let Some(touch_point) = self.touch_state.active_touches.remove(&slot) else {
+            return;
+        };
+
+        // 1. Locked session handling
+        if !matches!(self.session_lock, crate::state::SessionLock::Unlocked) {
+            let touch_handle = self.seat.get_touch().unwrap();
+            let raw_event = UpEvent {
+                slot,
+                serial,
+                time,
+            };
+            touch_handle.up(self, &raw_event);
+            touch_handle.frame(self);
+            return;
+        }
+
+        // 2. Unlocked session handling
+        if self.touch_state.gesture_active != TouchGestureMode::None {
+            if self.touch_state.active_touches.is_empty() {
+                self.touch_state.gesture_active = TouchGestureMode::None;
+            }
+        } else if let Some(ref _focus) = touch_point.focus {
+            if let Some(touch_handle) = self.seat.get_touch() {
+                let raw_event = UpEvent {
+                    slot,
+                    serial,
+                    time,
+                };
+                touch_handle.up(self, &raw_event);
+            }
+        }
+    }
+
+    pub fn on_touch_cancel<I: InputBackend>(&mut self, _event: I::TouchCancelEvent) {
+        if let Some(touch_handle) = self.seat.get_touch() {
+            touch_handle.cancel(self);
+        }
+        self.touch_state.active_touches.clear();
+        self.touch_state.gesture_active = TouchGestureMode::None;
+    }
+
+    pub fn on_touch_frame<I: InputBackend>(&mut self, _event: I::TouchFrameEvent) {
+        if let Some(touch_handle) = self.seat.get_touch() {
+            touch_handle.frame(self);
+        }
+    }
+}

--- a/src/state/init.rs
+++ b/src/state/init.rs
@@ -238,6 +238,7 @@ impl DriftWm {
             ..Default::default()
         });
         seat.add_pointer();
+        seat.add_touch();
 
         let autostart = config.autostart.clone();
         let edge_pan_cursor = config.edge_pan_cursor;
@@ -354,6 +355,7 @@ impl DriftWm {
             last_titlebar_click: None,
             errors: init_errors,
             cursor_edge_pan: edge_pan_cursor,
+            touch_state: crate::input::touch::TouchState::new(),
         }
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -581,6 +581,8 @@ pub struct DriftWm {
     /// touches a screen edge. Toggled by
     /// [`Action::ToggleCursorPan`](driftwm::config::Action::ToggleCursorPan).
     pub cursor_edge_pan: bool,
+
+    pub touch_state: crate::input::touch::TouchState,
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Adds full touchscreen support and multi-touch infinite canvas gestures, enabling trackpad-like navigation (pan, zoom, pinch) directly on touchscreen devices.

- **Compositor Seat Capability**: Registered touchscreen support (`seat.add_touch()`) so Wayland clients are aware of touch input availability.
- **Configurability**: Added a new `[touch]` section to the configuration to toggle touch settings, adjust gesture zoom/pan sensitivity, and control whether touching a window focuses/raises it.
- **Multi-Touch State Tracker**: Added slot-based hardware touch-point tracking in `src/input/touch.rs` to handle simultaneous touches correctly.
- **Wayland Client Forwarding**: Maps absolute screen coordinates into standard Wayland surface coordinates to interact normally with client windows/layers.
- **Infinite Canvas Gestures**:
  - **1-Finger Drag**: Drags/pans the viewport around the infinite 2D plane.
  - **2-Finger Pinch**: Performs anchor-midpoint zoom-in/out on the viewport.

