### PR TITLE
feat: add graphics tablet support and fix Nix development shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ window-search script that lets you search and jump to any open window.
 - New window placement: in viewport center (default), under cursor, or snapped adjacent to the focused window's cluster
 - Click-to-focus (default) or focus-follows-mouse (sloppy focus)
 - Session lock (swaylock), idle notify (swayidle/hypridle)
+- **Graphics tablet support**: Full `wp_tablet_manager_v2` integration (for Krita, GIMP, etc.) with absolute coordinates mapped to the infinite canvas, tilt/pressure/rotation axes, and legacy application pointer emulation.
 - Screen capture: screencasting (OBS, Firefox, Discord) and screenshots, incl. built-in [canvas/DPI capture](docs/ipc.md#screenshots)
 - 40+ Wayland protocols
 - [IPC control](docs/ipc.md): script the compositor over a Unix socket with `driftwm msg`

--- a/config.reference.toml
+++ b/config.reference.toml
@@ -77,6 +77,9 @@
 # accel_profile = "flat"      # "flat" or "adaptive"
 # natural_scroll = false      # reverse scroll direction
 
+[input.tablet]
+# map_to_output = "none"      # map tablet absolute coordinates to a specific output by name (e.g., "eDP-1")
+
 [cursor]
 # theme = "none"             # XCURSOR_THEME; "none" = inherit from environment (e.g. "Adwaita")
 # size = 0                    # XCURSOR_SIZE; 0 = inherit from environment (e.g. 24)

--- a/dev/docs/smithay-api.md
+++ b/dev/docs/smithay-api.md
@@ -124,6 +124,27 @@ delegate_cursor_shape!(DriftWm);
 // Also need: impl TabletSeatHandler for DriftWm {}
 ```
 
+### TabletSeat / TabletSeatHandler (`tablet-v2` protocol)
+
+`wp_tablet_manager_v2` is used to expose high-definition graphics tablet pen input (pressure, tilt, rotation) to drawing tools like Krita.
+
+```rust
+// Init:
+let tablet_state = TabletManagerState::new::<DriftWm>(&dh);
+delegate_tablet_manager!(DriftWm);
+
+// Impl:
+impl TabletSeatHandler for DriftWm {
+    fn tablet_tool_image(
+        &mut self,
+        _tool: &smithay::backend::input::TabletToolDescriptor,
+        image: CursorImageStatus,
+    ) {
+        self.cursor.cursor_status = image;
+    }
+}
+```
+
 ### MemoryRenderBuffer
 Source: `src/backend/renderer/element/memory.rs`
 ```rust

--- a/flake.nix
+++ b/flake.nix
@@ -102,7 +102,7 @@
       };
 
       devShells.${system}.default = pkgs.mkShell {
-        inherit nativeBuildInputs buildInputs;
+        inputsFrom = [ self.packages.${system}.default ];
 
         LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibs;
       };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -95,6 +95,7 @@ pub struct Config {
     pub background: BackgroundConfig,
     pub trackpad: TrackpadSettings,
     pub mouse_device: MouseDeviceSettings,
+    pub tablet: TabletSettings,
     pub gesture_thresholds: GestureThresholds,
     pub layout_independent: bool,
     pub keyboard_layout: KeyboardLayout,
@@ -511,6 +512,22 @@ impl Config {
             }
         };
 
+        let tablet = TabletSettings {
+            map_to_output: raw.input.tablet.map_to_output.clone().filter(|o| o.as_str() != "none"),
+            mappings: raw
+                .input
+                .tablet
+                .mappings
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|m| TabletMappingSettings {
+                    name: m.name,
+                    map_to_output: m.map_to_output,
+                })
+                .collect(),
+        };
+
         let gesture_thresholds = GestureThresholds {
             swipe_distance: non_negative(
                 raw.gestures.swipe_threshold.unwrap_or(12.0),
@@ -732,6 +749,7 @@ impl Config {
             backend,
             trackpad,
             mouse_device,
+            tablet,
             gesture_thresholds,
             layout_independent: raw.input.keyboard.layout_independent.unwrap_or(true),
             keyboard_layout,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -52,6 +52,21 @@ pub(super) struct InputConfig {
     pub keyboard: KeyboardConfig,
     pub trackpad: TrackpadConfig,
     pub mouse: MouseDeviceFileConfig,
+    pub tablet: TabletFileConfig,
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct TabletFileConfig {
+    pub map_to_output: Option<String>,
+    pub mappings: Option<Vec<TabletMappingFileConfig>>,
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct TabletMappingFileConfig {
+    pub name: String,
+    pub map_to_output: String,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -390,6 +390,18 @@ impl Default for MouseDeviceSettings {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct TabletMappingSettings {
+    pub name: String,
+    pub map_to_output: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TabletSettings {
+    pub map_to_output: Option<String>,
+    pub mappings: Vec<TabletMappingSettings>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct GestureThresholds {
     pub swipe_distance: f64,
     pub pinch_in_scale: f64,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -18,7 +18,7 @@ use smithay::{
     delegate_keyboard_shortcuts_inhibit, delegate_output, delegate_pointer_constraints,
     delegate_pointer_gestures, delegate_presentation, delegate_primary_selection,
     delegate_relative_pointer, delegate_seat, delegate_security_context,
-    delegate_single_pixel_buffer, delegate_text_input_manager, delegate_viewporter,
+    delegate_single_pixel_buffer, delegate_tablet_manager, delegate_text_input_manager, delegate_viewporter,
     delegate_virtual_keyboard_manager, delegate_xdg_activation,
     input::{
         Seat, SeatHandler, SeatState,
@@ -185,7 +185,17 @@ impl OutputHandler for DriftWm {}
 
 delegate_output!(DriftWm);
 
-impl TabletSeatHandler for DriftWm {}
+impl TabletSeatHandler for DriftWm {
+    fn tablet_tool_image(
+        &mut self,
+        _tool: &smithay::backend::input::TabletToolDescriptor,
+        image: CursorImageStatus,
+    ) {
+        self.cursor.cursor_status = image;
+    }
+}
+
+delegate_tablet_manager!(DriftWm);
 
 delegate_cursor_shape!(DriftWm);
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,6 +2,7 @@ mod actions;
 pub(crate) mod gestures;
 pub(crate) mod keyboard;
 mod pointer;
+pub(crate) mod tablet;
 
 use smithay::{
     backend::input::{
@@ -216,6 +217,12 @@ impl DriftWm {
             InputEvent::GesturePinchEnd { event } => self.on_gesture_pinch_end::<I>(event),
             InputEvent::GestureHoldBegin { event } => self.on_gesture_hold_begin::<I>(event),
             InputEvent::GestureHoldEnd { event } => self.on_gesture_hold_end::<I>(event),
+            InputEvent::DeviceAdded { device } => self.on_device_added::<I>(&device),
+            InputEvent::DeviceRemoved { device } => self.on_device_removed::<I>(&device),
+            InputEvent::TabletToolAxis { event } => self.on_tablet_tool_axis::<I>(event),
+            InputEvent::TabletToolProximity { event } => self.on_tablet_tool_proximity::<I>(event),
+            InputEvent::TabletToolTip { event } => self.on_tablet_tool_tip::<I>(event),
+            InputEvent::TabletToolButton { event } => self.on_tablet_tool_button::<I>(event),
             _ => {}
         }
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -422,6 +422,7 @@ impl DriftWm {
         &mut self,
         event: I::PointerMotionAbsoluteEvent,
     ) {
+        self.cursor.tablet_active = false;
         let output = match self.active_output() {
             Some(o) => o,
             None => return,
@@ -485,6 +486,7 @@ impl DriftWm {
     /// Multi-monitor aware: converts to layout space for output crossing,
     /// then to target output's canvas coords.
     fn on_pointer_motion_relative<I: InputBackend>(&mut self, event: I::PointerMotionEvent) {
+        self.cursor.tablet_active = false;
         // When locked, pointer only targets the lock surface
         if !matches!(self.session_lock, crate::state::SessionLock::Unlocked) {
             let pointer = self.seat.get_pointer().unwrap();

--- a/src/input/pointer.rs
+++ b/src/input/pointer.rs
@@ -71,6 +71,7 @@ impl DriftWm {
     /// 2. Normal click on window → focus + raise + forward to client
     /// 3. Left-click on empty canvas → pan canvas
     pub(super) fn on_pointer_button<I: InputBackend>(&mut self, event: I::PointerButtonEvent) {
+        self.cursor.tablet_active = false;
         // Outputs can transiently disappear (cable unplug, GPU resume race);
         // bail out so downstream active_output() / element_location() can't panic.
         if self.space.outputs().next().is_none() {

--- a/src/input/tablet.rs
+++ b/src/input/tablet.rs
@@ -1,0 +1,212 @@
+use smithay::{
+    backend::input::{
+        AbsolutePositionEvent, ButtonState, Device, DeviceCapability, Event, InputBackend,
+        ProximityState, TabletToolButtonEvent, TabletToolEvent, TabletToolProximityEvent,
+        TabletToolTipEvent, TabletToolTipState,
+    },
+    input::pointer::MotionEvent,
+    utils::SERIAL_COUNTER,
+    wayland::tablet_manager::{TabletDescriptor, TabletSeatTrait},
+};
+
+use crate::state::DriftWm;
+use driftwm::canvas::{ScreenPos, screen_to_canvas};
+
+impl DriftWm {
+    pub fn on_device_added<I: InputBackend>(&mut self, device: &I::Device) {
+        if device.has_capability(DeviceCapability::TabletTool) {
+            let tablet_seat = self.seat.tablet_seat();
+            let desc = TabletDescriptor::from(device);
+            tablet_seat.add_tablet::<Self>(&self.display_handle, &desc);
+        }
+    }
+
+    pub fn on_device_removed<I: InputBackend>(&mut self, device: &I::Device) {
+        if device.has_capability(DeviceCapability::TabletTool) {
+            let tablet_seat = self.seat.tablet_seat();
+            let desc = TabletDescriptor::from(device);
+            tablet_seat.remove_tablet(&desc);
+            if tablet_seat.count_tablets() == 0 {
+                tablet_seat.clear_tools();
+            }
+        }
+    }
+
+    pub fn on_tablet_tool_axis<I: InputBackend>(&mut self, event: I::TabletToolAxisEvent) {
+        let output = match self.active_output() {
+            Some(o) => o,
+            None => return,
+        };
+        let Some(output_geo) = self.space.output_geometry(&output) else {
+            return;
+        };
+
+        // Absolute coordinate from 0.0 to 1.0 mapped to output size
+        let screen_pos = event.position_transformed(output_geo.size);
+        let canvas_pos = screen_to_canvas(ScreenPos(screen_pos), self.camera(), self.zoom()).0;
+
+        let serial = SERIAL_COUNTER.next_serial();
+        let time = event.time_msec();
+
+        // Update pointer in seat so normal menus/hover work for legacy applications
+        let pointer = self.seat.get_pointer().unwrap();
+        let old_focus = pointer.current_focus();
+        let under = self.pointer_focus_under(screen_pos, canvas_pos);
+
+        pointer.motion(
+            self,
+            under.clone(),
+            &MotionEvent {
+                location: canvas_pos,
+                serial,
+                time,
+            },
+        );
+        pointer.frame(self);
+        self.update_decoration_cursor(canvas_pos);
+        self.update_pointer_constraint(old_focus);
+        self.maybe_hover_focus(canvas_pos);
+        self.refresh_cursor_edge_pan();
+
+        // Forward native tablet events to supporting clients
+        let tablet_seat = self.seat.tablet_seat();
+        let tablet = tablet_seat.get_tablet(&TabletDescriptor::from(&event.device()));
+        let tool = tablet_seat.get_tool(&event.tool());
+
+        if let (Some(tablet), Some(tool)) = (tablet, tool) {
+            if event.pressure_has_changed() {
+                tool.pressure(event.pressure());
+            }
+            if event.distance_has_changed() {
+                tool.distance(event.distance());
+            }
+            if event.tilt_has_changed() {
+                tool.tilt(event.tilt());
+            }
+            if event.slider_has_changed() {
+                tool.slider_position(event.slider_position());
+            }
+            if event.rotation_has_changed() {
+                tool.rotation(event.rotation());
+            }
+            if event.wheel_has_changed() {
+                tool.wheel(event.wheel_delta(), event.wheel_delta_discrete());
+            }
+
+            let wl_surface_and_pos = under.as_ref().map(|(focus_target, relative_pos)| {
+                (focus_target.0.clone(), *relative_pos)
+            });
+
+            tool.motion(
+                canvas_pos,
+                wl_surface_and_pos,
+                &tablet,
+                serial,
+                time,
+            );
+        }
+    }
+
+    pub fn on_tablet_tool_proximity<I: InputBackend>(&mut self, event: I::TabletToolProximityEvent) {
+        let output = match self.active_output() {
+            Some(o) => o,
+            None => return,
+        };
+        let Some(output_geo) = self.space.output_geometry(&output) else {
+            return;
+        };
+
+        let screen_pos = event.position_transformed(output_geo.size);
+        let canvas_pos = screen_to_canvas(ScreenPos(screen_pos), self.camera(), self.zoom()).0;
+
+        let serial = SERIAL_COUNTER.next_serial();
+        let time = event.time_msec();
+
+        let under = self.pointer_focus_under(screen_pos, canvas_pos);
+
+        let tablet_seat = self.seat.tablet_seat();
+        let display_handle = self.display_handle.clone();
+        let tool = tablet_seat.add_tool::<Self>(self, &display_handle, &event.tool());
+        let tablet = tablet_seat.get_tablet(&TabletDescriptor::from(&event.device()));
+
+        if let Some(tablet) = tablet {
+            match event.state() {
+                ProximityState::In => {
+                    if let Some((focus_target, relative_pos)) = under {
+                        tool.proximity_in(
+                            canvas_pos,
+                            (focus_target.0, relative_pos),
+                            &tablet,
+                            serial,
+                            time,
+                        );
+                    }
+                }
+                ProximityState::Out => {
+                    tool.proximity_out(time);
+                }
+            }
+        }
+    }
+
+    pub fn on_tablet_tool_tip<I: InputBackend>(&mut self, event: I::TabletToolTipEvent) {
+        let tablet_seat = self.seat.tablet_seat();
+        let tool = tablet_seat.get_tool(&event.tool());
+
+        let Some(tool) = tool else {
+            return;
+        };
+
+        let serial = SERIAL_COUNTER.next_serial();
+        let time = event.time_msec();
+
+        match event.tip_state() {
+            TabletToolTipState::Down => {
+                tool.tip_down(serial, time);
+
+                // Emulate pointer button press for drawing and clicking in normal apps
+                let pointer = self.seat.get_pointer().unwrap();
+                pointer.button(
+                    self,
+                    &smithay::input::pointer::ButtonEvent {
+                        button: 0x110, // BTN_LEFT
+                        state: ButtonState::Pressed,
+                        serial,
+                        time,
+                    },
+                );
+                pointer.frame(self);
+            }
+            TabletToolTipState::Up => {
+                tool.tip_up(time);
+
+                // Emulate pointer button release
+                let pointer = self.seat.get_pointer().unwrap();
+                pointer.button(
+                    self,
+                    &smithay::input::pointer::ButtonEvent {
+                        button: 0x110, // BTN_LEFT
+                        state: ButtonState::Released,
+                        serial,
+                        time,
+                    },
+                );
+                pointer.frame(self);
+            }
+        }
+    }
+
+    pub fn on_tablet_tool_button<I: InputBackend>(&mut self, event: I::TabletToolButtonEvent) {
+        let tablet_seat = self.seat.tablet_seat();
+        let tool = tablet_seat.get_tool(&event.tool());
+
+        if let Some(tool) = tool {
+            tool.button(
+                event.button(),
+                event.button_state(),
+                SERIAL_COUNTER.next_serial(),
+                event.time_msec(),
+            );
+        }
+    }
+}

--- a/src/input/tablet.rs
+++ b/src/input/tablet.rs
@@ -53,6 +53,7 @@ impl DriftWm {
     }
 
     pub fn on_tablet_tool_axis<I: InputBackend>(&mut self, event: I::TabletToolAxisEvent) {
+        self.cursor.tablet_active = true;
         let output = match self.tablet_output(&event.device().name()) {
             Some(o) => o,
             None => return,
@@ -152,6 +153,7 @@ impl DriftWm {
         if let Some(tablet) = tablet {
             match event.state() {
                 ProximityState::In => {
+                    self.cursor.tablet_active = true;
                     if let Some((focus_target, relative_pos)) = under {
                         tool.proximity_in(
                             canvas_pos,
@@ -163,6 +165,7 @@ impl DriftWm {
                     }
                 }
                 ProximityState::Out => {
+                    self.cursor.tablet_active = false;
                     tool.proximity_out(time);
                 }
             }

--- a/src/input/tablet.rs
+++ b/src/input/tablet.rs
@@ -5,6 +5,7 @@ use smithay::{
         TabletToolTipEvent, TabletToolTipState,
     },
     input::pointer::MotionEvent,
+    output::Output,
     utils::SERIAL_COUNTER,
     wayland::tablet_manager::{TabletDescriptor, TabletSeatTrait},
 };
@@ -13,6 +14,25 @@ use crate::state::DriftWm;
 use driftwm::canvas::{ScreenPos, screen_to_canvas};
 
 impl DriftWm {
+    pub fn tablet_output(&self, device_name: &str) -> Option<Output> {
+        // 1. Check specific mappings first
+        for mapping in &self.config.tablet.mappings {
+            if device_name.to_lowercase().contains(&mapping.name.to_lowercase()) {
+                if let Some(output) = self.space.outputs().find(|o| o.name() == mapping.map_to_output) {
+                    return Some(output.clone());
+                }
+            }
+        }
+        // 2. Fall back to global map_to_output
+        if let Some(ref target) = self.config.tablet.map_to_output {
+            if let Some(output) = self.space.outputs().find(|o| o.name() == *target) {
+                return Some(output.clone());
+            }
+        }
+        // 3. Fall back to active output
+        self.active_output()
+    }
+
     pub fn on_device_added<I: InputBackend>(&mut self, device: &I::Device) {
         if device.has_capability(DeviceCapability::TabletTool) {
             let tablet_seat = self.seat.tablet_seat();
@@ -33,7 +53,7 @@ impl DriftWm {
     }
 
     pub fn on_tablet_tool_axis<I: InputBackend>(&mut self, event: I::TabletToolAxisEvent) {
-        let output = match self.active_output() {
+        let output = match self.tablet_output(&event.device().name()) {
             Some(o) => o,
             None => return,
         };
@@ -108,7 +128,7 @@ impl DriftWm {
     }
 
     pub fn on_tablet_tool_proximity<I: InputBackend>(&mut self, event: I::TabletToolProximityEvent) {
-        let output = match self.active_output() {
+        let output = match self.tablet_output(&event.device().name()) {
             Some(o) => o,
             None => return,
         };

--- a/src/render/cursor.rs
+++ b/src/render/cursor.rs
@@ -33,41 +33,46 @@ pub fn build_cursor_elements(
     let physical_pos: Point<f64, Physical> = screen_pos.to_physical_precise_round(scale);
 
     let status = state.cursor.cursor_status.clone();
-    let mut result = match status {
-        CursorImageStatus::Hidden => vec![],
-        CursorImageStatus::Surface(ref surface) => {
-            if !surface.alive() {
-                state.cursor.cursor_status = CursorImageStatus::default_named();
-                return build_xcursor_elements(state, renderer, physical_pos, "default", alpha);
+    let mut result = if state.cursor.tablet_active && status != CursorImageStatus::Hidden {
+        build_xcursor_elements(state, renderer, physical_pos, "tablet_dot", alpha)
+    } else {
+        match status {
+            CursorImageStatus::Hidden => vec![],
+            CursorImageStatus::Surface(ref surface) => {
+                if !surface.alive() {
+                    state.cursor.cursor_status = CursorImageStatus::default_named();
+                    build_xcursor_elements(state, renderer, physical_pos, "default", alpha)
+                } else {
+                    let hotspot = with_states(surface, |states| {
+                        states
+                            .data_map
+                            .get::<CursorImageSurfaceData>()
+                            .map(|d| d.lock().unwrap().hotspot)
+                            .unwrap_or_default()
+                    });
+                    let pos: Point<i32, Physical> = (
+                        (physical_pos.x - hotspot.x as f64) as i32,
+                        (physical_pos.y - hotspot.y as f64) as i32,
+                    )
+                        .into();
+                    let elems: Vec<WaylandSurfaceRenderElement<GlesRenderer>> =
+                        smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
+                            renderer,
+                            surface,
+                            pos,
+                            Scale::from(1.0),
+                            alpha,
+                            Kind::Cursor,
+                        );
+                    elems
+                        .into_iter()
+                        .map(|e| OutputRenderElements::CursorSurface(e.into()))
+                        .collect()
+                }
             }
-            let hotspot = with_states(surface, |states| {
-                states
-                    .data_map
-                    .get::<CursorImageSurfaceData>()
-                    .map(|d| d.lock().unwrap().hotspot)
-                    .unwrap_or_default()
-            });
-            let pos: Point<i32, Physical> = (
-                (physical_pos.x - hotspot.x as f64) as i32,
-                (physical_pos.y - hotspot.y as f64) as i32,
-            )
-                .into();
-            let elems: Vec<WaylandSurfaceRenderElement<GlesRenderer>> =
-                smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
-                    renderer,
-                    surface,
-                    pos,
-                    Scale::from(1.0),
-                    alpha,
-                    Kind::Cursor,
-                );
-            elems
-                .into_iter()
-                .map(|e| OutputRenderElements::CursorSurface(e.into()))
-                .collect()
-        }
-        CursorImageStatus::Named(icon) => {
-            build_xcursor_elements(state, renderer, physical_pos, icon.name(), alpha)
+            CursorImageStatus::Named(icon) => {
+                build_xcursor_elements(state, renderer, physical_pos, icon.name(), alpha)
+            }
         }
     };
 

--- a/src/state/cursor.rs
+++ b/src/state/cursor.rs
@@ -33,6 +33,8 @@ pub struct CursorState {
     pub exec_cursor_show_at: Option<Instant>,
     /// Loading cursor deadline.
     pub exec_cursor_deadline: Option<Instant>,
+    /// True if the last input was from a tablet and the pen is in proximity.
+    pub tablet_active: bool,
 }
 
 impl CursorState {
@@ -44,6 +46,7 @@ impl CursorState {
             cursor_buffers: HashMap::new(),
             exec_cursor_show_at: None,
             exec_cursor_deadline: None,
+            tablet_active: false,
         }
     }
 
@@ -71,13 +74,18 @@ impl CursorState {
         target_size: u32,
     ) -> Option<&CursorFrames> {
         if !self.cursor_buffers.contains_key(name) {
-            let from_theme = load_from_theme(name, theme_name, target_size);
-            let frames = match from_theme {
-                Some(f) => f,
-                None if name == "default" => fallback_frames(),
-                None => return None,
-            };
-            self.cursor_buffers.insert(name.to_string(), frames);
+            if name == "tablet_dot" {
+                let frames = dot_frames();
+                self.cursor_buffers.insert(name.to_string(), frames);
+            } else {
+                let from_theme = load_from_theme(name, theme_name, target_size);
+                let frames = match from_theme {
+                    Some(f) => f,
+                    None if name == "default" => fallback_frames(),
+                    None => return None,
+                };
+                self.cursor_buffers.insert(name.to_string(), frames);
+            }
         }
         self.cursor_buffers.get(name)
     }
@@ -139,6 +147,47 @@ fn fallback_frames() -> CursorFrames {
         None,
     );
     let hotspot = Point::from(FALLBACK_CURSOR_HOTSPOT);
+    CursorFrames {
+        frames: vec![(buffer, hotspot, 0)],
+        total_duration_ms: 0,
+    }
+}
+
+fn dot_frames() -> CursorFrames {
+    let mut pixels = vec![0u8; 16 * 16 * 4];
+    for y in 0..16 {
+        for x in 0..16 {
+            let dx = x as f32 - 7.5;
+            let dy = y as f32 - 7.5;
+            let dist = (dx * dx + dy * dy).sqrt();
+            let idx = (y * 16 + x) * 4;
+            if dist <= 2.5 {
+                pixels[idx] = 255;     // B
+                pixels[idx + 1] = 255; // G
+                pixels[idx + 2] = 255; // R
+                pixels[idx + 3] = 255; // A
+            } else if dist <= 4.0 {
+                pixels[idx] = 0;       // B
+                pixels[idx + 1] = 0;   // G
+                pixels[idx + 2] = 0;   // R
+                pixels[idx + 3] = 255; // A
+            } else {
+                pixels[idx] = 0;
+                pixels[idx + 1] = 0;
+                pixels[idx + 2] = 0;
+                pixels[idx + 3] = 0;
+            }
+        }
+    }
+    let buffer = MemoryRenderBuffer::from_slice(
+        &pixels,
+        Fourcc::Argb8888,
+        (16, 16),
+        1,
+        Transform::Normal,
+        None,
+    );
+    let hotspot = Point::from((8, 8));
     CursorFrames {
         frames: vec![(buffer, hotspot, 0)],
         total_duration_ms: 0,

--- a/src/state/init.rs
+++ b/src/state/init.rs
@@ -161,6 +161,8 @@ impl DriftWm {
         );
         let session_lock_manager_state =
             SessionLockManagerState::new::<Self, _>(&dh, client_is_unrestricted);
+        let tablet_state =
+            smithay::wayland::tablet_manager::TabletManagerState::new::<Self>(&dh);
         let gamma_control_manager_state =
             driftwm::protocols::gamma_control::GammaControlManagerState::new::<Self, _>(
                 &dh,
@@ -301,6 +303,7 @@ impl DriftWm {
             xdg_foreign_state,
             background_effect_state,
             session_lock_manager_state,
+            tablet_state,
             gamma_control_manager_state,
             session_lock: SessionLock::Unlocked,
             lock_surfaces: HashMap::new(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -443,6 +443,8 @@ pub struct DriftWm {
     #[allow(dead_code)]
     pub background_effect_state: BackgroundEffectState,
     pub session_lock_manager_state: SessionLockManagerState,
+    #[allow(dead_code)]
+    pub tablet_state: smithay::wayland::tablet_manager::TabletManagerState,
     pub gamma_control_manager_state: driftwm::protocols::gamma_control::GammaControlManagerState,
     pub session_lock: SessionLock,
     pub lock_surfaces: HashMap<Output, LockSurface>,


### PR DESCRIPTION
Implement graphics tablet (digitizer) support via the `wp_tablet_manager_v2` Wayland protocol, enabling high-definition pen input and stylus hover tracking on the infinite canvas.

- Initialize `TabletManagerState` on the compositor state and delegate the protocol.
- Track physical graphics tablet devices and register tools on hotplug.
- Project absolute tablet hardware coordinates to screen coordinates and convert them to absolute world space using the infinite canvas coordinate transforms.
- Forward high-definition stylus inputs (tilt, pressure, distance, rotation) to native tablet-aware clients like Krita or GIMP.
- Emulate standard pointer buttons and motion for non-tablet-aware legacy apps and server-side window title/border decorations.
- Correctly route stylus hover proximity enter/exit states.
- Clean up Nix `devShell` definition in `flake.nix` by inheriting inputs from the default package using `inputsFrom = [...]` to guarantee all dev-tools build correctly.
- Update user-facing and developer documentation with tablet configuration details.
- [ ] user configuration for mapping a graphics tablet input to output

_see also: https://github.com/malbiruk/driftwm/issues/118_