### PR TITLE
Add ext_data_control_manager_v1 support

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -14,12 +14,12 @@ use smithay::wayland::seat::WaylandFocus;
 use smithay::{
     backend::renderer::ImportDma,
     delegate_cursor_shape, delegate_data_control, delegate_data_device, delegate_dmabuf,
-    delegate_fractional_scale, delegate_idle_inhibit, delegate_input_method_manager,
-    delegate_keyboard_shortcuts_inhibit, delegate_output, delegate_pointer_constraints,
-    delegate_pointer_gestures, delegate_presentation, delegate_primary_selection,
-    delegate_relative_pointer, delegate_seat, delegate_security_context,
-    delegate_single_pixel_buffer, delegate_text_input_manager, delegate_viewporter,
-    delegate_virtual_keyboard_manager, delegate_xdg_activation,
+    delegate_ext_data_control, delegate_fractional_scale, delegate_idle_inhibit,
+    delegate_input_method_manager, delegate_keyboard_shortcuts_inhibit, delegate_output,
+    delegate_pointer_constraints, delegate_pointer_gestures, delegate_presentation,
+    delegate_primary_selection, delegate_relative_pointer, delegate_seat,
+    delegate_security_context, delegate_single_pixel_buffer, delegate_text_input_manager,
+    delegate_viewporter, delegate_virtual_keyboard_manager, delegate_xdg_activation,
     input::{
         Seat, SeatHandler, SeatState,
         dnd::{self, DnDGrab},
@@ -48,6 +48,10 @@ use smithay::{
             SelectionHandler,
             data_device::{
                 DataDeviceHandler, DataDeviceState, WaylandDndGrabHandler, set_data_device_focus,
+            },
+            ext_data_control::{
+                DataControlHandler as ExtDataControlHandler,
+                DataControlState as ExtDataControlState,
             },
             primary_selection::{
                 PrimarySelectionHandler, PrimarySelectionState, set_primary_focus,
@@ -308,6 +312,14 @@ impl DataControlHandler for DriftWm {
 }
 
 delegate_data_control!(DriftWm);
+
+impl ExtDataControlHandler for DriftWm {
+    fn data_control_state(&mut self) -> &mut ExtDataControlState {
+        &mut self.ext_data_control_state
+    }
+}
+
+delegate_ext_data_control!(DriftWm);
 
 impl PointerConstraintsHandler for DriftWm {
     fn new_constraint(&mut self, _surface: &WlSurface, _pointer: &PointerHandle<Self>) {

--- a/src/state/init.rs
+++ b/src/state/init.rs
@@ -28,8 +28,9 @@ use smithay::{
         relative_pointer::RelativePointerManagerState,
         security_context::SecurityContextState,
         selection::{
-            data_device::DataDeviceState, primary_selection::PrimarySelectionState,
-            wlr_data_control::DataControlState,
+            data_device::DataDeviceState,
+            ext_data_control::DataControlState as ExtDataControlState,
+            primary_selection::PrimarySelectionState, wlr_data_control::DataControlState,
         },
         session_lock::SessionLockManagerState,
         shell::{
@@ -100,6 +101,11 @@ impl DriftWm {
         SinglePixelBufferState::new::<Self>(&dh);
         let primary_selection_state = PrimarySelectionState::new::<Self>(&dh);
         let data_control_state = DataControlState::new::<Self, _>(
+            &dh,
+            Some(&primary_selection_state),
+            client_is_unrestricted,
+        );
+        let ext_data_control_state = ExtDataControlState::new::<Self, _>(
             &dh,
             Some(&primary_selection_state),
             client_is_unrestricted,
@@ -274,6 +280,7 @@ impl DriftWm {
             xdg_activation_state,
             primary_selection_state,
             data_control_state,
+            ext_data_control_state,
             pointer_constraints_state,
             relative_pointer_state,
             keyboard_shortcuts_inhibit_state,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -56,6 +56,7 @@ use smithay::wayland::pointer_constraints::PointerConstraintsState;
 use smithay::wayland::presentation::PresentationState;
 use smithay::wayland::relative_pointer::RelativePointerManagerState;
 use smithay::wayland::security_context::SecurityContextState;
+use smithay::wayland::selection::ext_data_control::DataControlState as ExtDataControlState;
 use smithay::wayland::selection::primary_selection::PrimarySelectionState;
 use smithay::wayland::selection::wlr_data_control::DataControlState;
 use smithay::wayland::session_lock::{LockSurface, SessionLockManagerState, SessionLocker};
@@ -409,6 +410,7 @@ pub struct DriftWm {
     pub xdg_activation_state: XdgActivationState,
     pub primary_selection_state: PrimarySelectionState,
     pub data_control_state: DataControlState,
+    pub ext_data_control_state: ExtDataControlState,
     #[allow(dead_code)]
     pub pointer_constraints_state: PointerConstraintsState,
     #[allow(dead_code)]


### PR DESCRIPTION
Self explanatory :)

I use vicinae and it required `ext_data_control_manager_v1` for its clipboard manager capabilities, however driftwm only provided `zwlr_data_control_manager_v1` .