### PR TITLE
Make animate_blur affordable: one shared throttled blur instead of per-window scene re-renders

### DIFF
--- a/config.reference.toml
+++ b/config.reference.toml
@@ -176,9 +176,15 @@
 [effects]
 # blur_radius = 2                # number of Kawase down+up passes (default: 2)
 # blur_strength = 1.1            # per-pass texel spread (default: 1.1)
-# animate_blur = false           # re-blur every frame when the wallpaper is animated
-                                 # (expensive; default: false — blur is captured once and
-                                 # only refreshed when geometry/camera/static bg change)
+# animate_blur = false           # keep blur live under an animated wallpaper (default: false —
+                                 # blur is captured once and only refreshed when geometry/camera/
+                                 # static bg change). The background is blurred once into a shared
+                                 # full-output texture and each window slices its rect from it, so
+                                 # cost stays flat as windows are added. A window stacked over other
+                                 # windows falls back to an exact per-window blur at the same cadence.
+# animate_blur_fps = 20          # refresh rate of the shared animated blur (1-144). Animated
+                                 # wallpapers evolve slowly; well below the output rate still looks
+                                 # continuous through frosted glass. Camera moves force a refresh.
 
 [background]
 # # Five types: "default" (built-in dot-grid — the default), "shader", "tile",

--- a/docs/config.md
+++ b/docs/config.md
@@ -506,7 +506,13 @@ per-pass texel spread (default: 1.1)
 
 Default: `false`
 
-re-blur every frame when the wallpaper is animated (expensive; default: false — blur is captured once and only refreshed when geometry/camera/static bg change)
+keep blur live under an animated wallpaper (default: false — blur is captured once and only refreshed when geometry/camera/static bg change). The background is blurred once into a shared full-output texture and each window slices its rect from it, so cost stays flat as windows are added. A window stacked over other windows falls back to an exact per-window blur at the same cadence.
+
+### `animate_blur_fps`
+
+Default: `20`
+
+refresh rate of the shared animated blur (1-144). Animated wallpapers evolve slowly; well below the output rate still looks continuous through frosted glass. Camera moves force a refresh.
 
 ## `[background]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -506,7 +506,7 @@ per-pass texel spread (default: 1.1)
 
 Default: `false`
 
-keep blur live under an animated wallpaper (default: false — blur is captured once and only refreshed when geometry/camera/static bg change). The background is blurred once into a shared full-output texture and each window slices its rect from it, so cost stays flat as windows are added. A window stacked over other windows falls back to an exact per-window blur at the same cadence.
+keep blur live under an animated wallpaper (default: false — blur is captured once and only refreshed when geometry/camera/ static bg change). The background is blurred once into a shared full-output texture and each window slices its rect from it, so cost stays flat as windows are added. A window stacked over other windows falls back to an exact per-window blur at the same cadence.
 
 ### `animate_blur_fps`
 

--- a/src/config/parse_helpers.rs
+++ b/src/config/parse_helpers.rs
@@ -426,6 +426,7 @@ pub(super) fn parse_effects_config(raw: EffectsFileConfig, errors: &mut Warnings
             errors,
         ),
         animate_blur: raw.animate_blur.unwrap_or(false),
+        animate_blur_fps: raw.animate_blur_fps.unwrap_or(20).clamp(1, 144),
     }
 }
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -51,6 +51,7 @@ pub(super) struct EffectsFileConfig {
     pub blur_radius: Option<u32>,
     pub blur_strength: Option<f64>,
     pub animate_blur: Option<bool>,
+    pub animate_blur_fps: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -770,6 +770,10 @@ pub struct EffectsConfig {
     pub blur_radius: u32,
     pub blur_strength: f64,
     pub animate_blur: bool,
+    /// Refresh rate of the shared animated-background blur. Animated
+    /// wallpapers evolve slowly; re-blurring at a fraction of the output
+    /// rate looks continuous through frosted glass at a fraction of the cost.
+    pub animate_blur_fps: u32,
 }
 
 impl Default for EffectsConfig {
@@ -778,6 +782,7 @@ impl Default for EffectsConfig {
             blur_radius: 2,
             blur_strength: 1.1,
             animate_blur: false,
+            animate_blur_fps: 20,
         }
     }
 }

--- a/src/render/blur.rs
+++ b/src/render/blur.rs
@@ -317,6 +317,7 @@ pub(crate) fn process_blur_requests(
     pinned_prefix: usize,
     normal_prefix: usize,
     widget_prefix: usize,
+    background_start: usize,
 ) {
     use smithay::backend::renderer::Color32F;
     use smithay::backend::renderer::damage::OutputDamageTracker;
@@ -347,9 +348,68 @@ pub(crate) fn process_blur_requests(
     let geom_gen = state.render.blur_geometry_generation;
     let camera_gen = state.render.blur_camera_generation;
     // Animated background shaders update per frame but the element Id is stable,
-    // so the bg_hash optimisation can't detect the change. Re-blurring every frame
-    // is expensive, so it's opt-in via [effects].animate_blur.
+    // so the bg_hash optimisation can't detect the change. Re-blurring per
+    // window per frame re-renders the whole scene each time and scales with
+    // window count; instead the background is blurred ONCE into a shared
+    // full-output texture (throttled to [effects].animate_blur_fps, forced on
+    // camera moves) and each window slices its rect out of it. Trade-off: a
+    // window overlapping another window frosts only the background beneath.
     let animated_bg = state.render.background_is_animated && state.config.effects.animate_blur;
+    let mut shared_refreshed = false;
+    if animated_bg {
+        let min_interval =
+            std::time::Duration::from_secs_f64(1.0 / state.config.effects.animate_blur_fps as f64);
+        let camera_moved = state.render.shared_blur_camera_generation != camera_gen;
+        let due = state
+            .render
+            .shared_blur_at
+            .is_none_or(|at| at.elapsed() >= min_interval);
+        let size_ok = state
+            .render
+            .shared_blur
+            .as_ref()
+            .is_some_and(|(_, _, s)| *s == output_size);
+        if !size_ok {
+            let a =
+                Offscreen::<GlesTexture>::create_buffer(renderer, Fourcc::Abgr8888, out_buf_size);
+            let b =
+                Offscreen::<GlesTexture>::create_buffer(renderer, Fourcc::Abgr8888, out_buf_size);
+            if let (Ok(a), Ok(b)) = (a, b) {
+                state.render.shared_blur = Some((a, b, output_size));
+            }
+        }
+        if (due || camera_moved || !size_ok) && state.render.shared_blur.is_some() {
+            let (mut sa, mut sb, ssize) = state.render.shared_blur.take().unwrap();
+            let mut rendered = false;
+            if let Ok(mut target) = renderer.bind(&mut sa) {
+                let mut dt = OutputDamageTracker::new(output_size, output_scale, Transform::Normal);
+                rendered = dt
+                    .render_output(
+                        renderer,
+                        &mut target,
+                        0,
+                        &all_elements[background_start.min(all_elements.len())..],
+                        [0.0f32, 0.0, 0.0, 1.0],
+                    )
+                    .is_ok();
+            }
+            if rendered {
+                let _ = render_blur(
+                    renderer,
+                    &down_shader,
+                    &up_shader,
+                    &mut sa,
+                    &mut sb,
+                    blur_strength * output_scale as f32,
+                    blur_passes,
+                );
+                state.render.shared_blur_at = Some(std::time::Instant::now());
+                state.render.shared_blur_camera_generation = camera_gen;
+                shared_refreshed = true;
+            }
+            state.render.shared_blur = Some((sa, sb, ssize));
+        }
+    }
 
     // Precompute per-request behind depth (index into all_elements where "below this window" begins)
     let behind_starts: Vec<usize> = blur_requests
@@ -404,7 +464,7 @@ pub(crate) fn process_blur_requests(
             BlurLayer::Overlay | BlurLayer::Top | BlurLayer::Pinned
         ) && cache.last_camera_generation != camera_gen;
 
-        if background_changed || geom_changed || camera_dirty || animated_bg {
+        if background_changed || geom_changed || camera_dirty || (animated_bg && shared_refreshed) {
             cache.dirty = true;
         }
         if cache.force_dirty_frames > 0 {
@@ -435,6 +495,44 @@ pub(crate) fn process_blur_requests(
         let Some(cache) = state.render.blur_cache.get_mut(&req.surface_id) else {
             continue;
         };
+
+        // The shared slice is only exact when nothing but scene background
+        // lies beneath this window; a window stacked over other windows
+        // falls through to the per-window path (throttled by the same
+        // shared_refreshed cadence), so lower windows show in its frost.
+        if animated_bg && behind_starts[i] >= background_start {
+            // Slice this window's rect out of the shared blurred background.
+            // Already blurred full-screen, so edges see real neighbours and
+            // no padding is needed.
+            let Some((shared, _, _)) = state.render.shared_blur.as_ref() else {
+                continue;
+            };
+            let shared_src = shared.clone();
+            let Ok(mut target) = renderer.bind(&mut cache.texture) else {
+                continue;
+            };
+            let Ok(mut frame) = renderer.render(&mut target, win_size, Transform::Normal) else {
+                continue;
+            };
+            let _ = frame.clear(Color32F::TRANSPARENT, &[Rectangle::from_size(win_size)]);
+            let src_rect: Rectangle<f64, smithay::utils::Buffer> = Rectangle::new(
+                (req.screen_rect.loc.x as f64, req.screen_rect.loc.y as f64).into(),
+                (win_size.w as f64, win_size.h as f64).into(),
+            );
+            let _ = frame.render_texture_from_to(
+                &shared_src,
+                src_rect,
+                Rectangle::from_size(win_size),
+                &[Rectangle::from_size(win_size)],
+                &[],
+                Transform::Normal,
+                1.0,
+                None,
+                &[],
+            );
+            let _ = frame.finish();
+            continue;
+        }
 
         let behind = behind_starts[i];
         if last_bg_depth != Some(behind) {

--- a/src/render/blur.rs
+++ b/src/render/blur.rs
@@ -142,6 +142,19 @@ impl BlurCache {
     }
 }
 
+/// Per-output shared blurred-background state for `animate_blur`: ping-pong
+/// pair plus its refresh throttle. Keyed per output in `RenderCache` —
+/// outputs differ in size and render on their own vblanks, so one global
+/// entry would thrash (recreate + full re-blur on every size mismatch) the
+/// moment a second output exists.
+pub struct SharedBlur {
+    pub tex_a: GlesTexture,
+    pub tex_b: GlesTexture,
+    pub size: Size<i32, Physical>,
+    pub refreshed_at: Option<std::time::Instant>,
+    pub camera_generation: u64,
+}
+
 /// Padding around the blur crop so the Kawase reach never touches a texture
 /// edge: window-edge samples must see real backdrop, not clamped border
 /// pixels. Sized to the blur's worst-case reach at the deepest mip.
@@ -355,59 +368,70 @@ pub(crate) fn process_blur_requests(
     // camera moves) and each window slices its rect out of it. Trade-off: a
     // window overlapping another window frosts only the background beneath.
     let animated_bg = state.render.background_is_animated && state.config.effects.animate_blur;
+    let output_name = output.name();
     let mut shared_refreshed = false;
     if animated_bg {
         let min_interval =
             std::time::Duration::from_secs_f64(1.0 / state.config.effects.animate_blur_fps as f64);
-        let camera_moved = state.render.shared_blur_camera_generation != camera_gen;
-        let due = state
-            .render
-            .shared_blur_at
-            .is_none_or(|at| at.elapsed() >= min_interval);
         let size_ok = state
             .render
             .shared_blur
-            .as_ref()
-            .is_some_and(|(_, _, s)| *s == output_size);
+            .get(&output_name)
+            .is_some_and(|s| s.size == output_size);
         if !size_ok {
             let a =
                 Offscreen::<GlesTexture>::create_buffer(renderer, Fourcc::Abgr8888, out_buf_size);
             let b =
                 Offscreen::<GlesTexture>::create_buffer(renderer, Fourcc::Abgr8888, out_buf_size);
             if let (Ok(a), Ok(b)) = (a, b) {
-                state.render.shared_blur = Some((a, b, output_size));
+                state.render.shared_blur.insert(
+                    output_name.clone(),
+                    SharedBlur {
+                        tex_a: a,
+                        tex_b: b,
+                        size: output_size,
+                        refreshed_at: None,
+                        camera_generation: 0,
+                    },
+                );
             }
         }
-        if (due || camera_moved || !size_ok) && state.render.shared_blur.is_some() {
-            let (mut sa, mut sb, ssize) = state.render.shared_blur.take().unwrap();
-            let mut rendered = false;
-            if let Ok(mut target) = renderer.bind(&mut sa) {
-                let mut dt = OutputDamageTracker::new(output_size, output_scale, Transform::Normal);
-                rendered = dt
-                    .render_output(
+        if let Some(mut shared) = state.render.shared_blur.remove(&output_name) {
+            let camera_moved = shared.camera_generation != camera_gen;
+            let due = shared
+                .refreshed_at
+                .is_none_or(|at| at.elapsed() >= min_interval);
+            if due || camera_moved {
+                let mut rendered = false;
+                if let Ok(mut target) = renderer.bind(&mut shared.tex_a) {
+                    let mut dt =
+                        OutputDamageTracker::new(output_size, output_scale, Transform::Normal);
+                    rendered = dt
+                        .render_output(
+                            renderer,
+                            &mut target,
+                            0,
+                            &all_elements[background_start.min(all_elements.len())..],
+                            [0.0f32, 0.0, 0.0, 1.0],
+                        )
+                        .is_ok();
+                }
+                if rendered {
+                    let _ = render_blur(
                         renderer,
-                        &mut target,
-                        0,
-                        &all_elements[background_start.min(all_elements.len())..],
-                        [0.0f32, 0.0, 0.0, 1.0],
-                    )
-                    .is_ok();
+                        &down_shader,
+                        &up_shader,
+                        &mut shared.tex_a,
+                        &mut shared.tex_b,
+                        blur_strength * output_scale as f32,
+                        blur_passes,
+                    );
+                    shared.refreshed_at = Some(std::time::Instant::now());
+                    shared.camera_generation = camera_gen;
+                    shared_refreshed = true;
+                }
             }
-            if rendered {
-                let _ = render_blur(
-                    renderer,
-                    &down_shader,
-                    &up_shader,
-                    &mut sa,
-                    &mut sb,
-                    blur_strength * output_scale as f32,
-                    blur_passes,
-                );
-                state.render.shared_blur_at = Some(std::time::Instant::now());
-                state.render.shared_blur_camera_generation = camera_gen;
-                shared_refreshed = true;
-            }
-            state.render.shared_blur = Some((sa, sb, ssize));
+            state.render.shared_blur.insert(output_name.clone(), shared);
         }
     }
 
@@ -504,10 +528,10 @@ pub(crate) fn process_blur_requests(
             // Slice this window's rect out of the shared blurred background.
             // Already blurred full-screen, so edges see real neighbours and
             // no padding is needed.
-            let Some((shared, _, _)) = state.render.shared_blur.as_ref() else {
+            let Some(shared) = state.render.shared_blur.get(&output_name) else {
                 continue;
             };
-            let shared_src = shared.clone();
+            let shared_src = shared.tex_a.clone();
             let Ok(mut target) = renderer.bind(&mut cache.texture) else {
                 continue;
             };

--- a/src/render/blur.rs
+++ b/src/render/blur.rs
@@ -524,13 +524,16 @@ pub(crate) fn process_blur_requests(
         // lies beneath this window; a window stacked over other windows
         // falls through to the per-window path (throttled by the same
         // shared_refreshed cadence), so lower windows show in its frost.
-        if animated_bg && behind_starts[i] >= background_start {
+        // Missing shared textures (GL alloc failure) also fall through —
+        // skipping would insert this window's never-rendered texture as an
+        // invisible blur.
+        if animated_bg
+            && behind_starts[i] >= background_start
+            && let Some(shared) = state.render.shared_blur.get(&output_name)
+        {
             // Slice this window's rect out of the shared blurred background.
             // Already blurred full-screen, so edges see real neighbours and
             // no padding is needed.
-            let Some(shared) = state.render.shared_blur.get(&output_name) else {
-                continue;
-            };
             let shared_src = shared.tex_a.clone();
             let Ok(mut target) = renderer.bind(&mut cache.texture) else {
                 continue;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -15,8 +15,8 @@ mod tile_chunks_tiff;
 mod tile_worker;
 
 pub use background::{BackgroundElement, init_background, update_background_element};
-pub use blur::BlurCache;
 pub(crate) use blur::compile_blur_shaders;
+pub use blur::{BlurCache, SharedBlur};
 pub use capture::{render_capture_frames, render_screencopy, render_toplevel_captures};
 pub use cursor::build_cursor_elements;
 pub use elements::{

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1207,6 +1207,12 @@ pub fn compose_frame(
             + background_layer_elements.len(),
     );
     let cursor_count = cursor_elements.len();
+    // Everything from bottom_elements down is scene background for the
+    // shared animated blur (below all windows and widgets).
+    let background_suffix = bottom_elements.len()
+        + outline_elements.len()
+        + bg_elements.len()
+        + background_layer_elements.len();
     all_elements.extend(cursor_elements);
     all_elements.extend(overlay_elements);
     all_elements.extend(top_elements);
@@ -1218,6 +1224,7 @@ pub fn compose_frame(
     all_elements.extend(outline_elements);
     all_elements.extend(bg_elements);
     all_elements.extend(background_layer_elements);
+    let background_start = all_elements.len() - background_suffix;
 
     if !all_blur_requests.is_empty() {
         #[cfg(feature = "profile-with-tracy")]
@@ -1234,6 +1241,7 @@ pub fn compose_frame(
             pinned_prefix,
             normal_prefix,
             widget_prefix,
+            background_start,
         );
     }
 

--- a/src/state/reload.rs
+++ b/src/state/reload.rs
@@ -90,6 +90,10 @@ impl DriftWm {
         self.render.background_uses_camera = false;
         self.render.background_uses_zoom = false;
         self.render.cached_bg.clear();
+        // Shared animated-blur textures are only touched while `animate_blur`
+        // is on; without this, disabling it would strand two full-output
+        // textures (~66 MB at 4K) until exit.
+        self.render.shared_blur.clear();
         self.render.tile_shader = None;
         self.render.tile_mirror_shader = None;
         self.render.wallpaper_shader = None;

--- a/src/state/render_cache.rs
+++ b/src/state/render_cache.rs
@@ -33,10 +33,9 @@ pub struct RenderCache {
     pub blur_camera_generation: u64,
     /// Shared full-output blurred background for `animate_blur`: ping-pong
     /// pair, blurred once per refresh and sliced per window, so cost stops
-    /// scaling with the number of blurred windows.
-    pub shared_blur: Option<(GlesTexture, GlesTexture, Size<i32, Physical>)>,
-    pub shared_blur_at: Option<std::time::Instant>,
-    pub shared_blur_camera_generation: u64,
+    /// scaling with the number of blurred windows. Keyed by output name —
+    /// outputs differ in size and render on their own vblanks.
+    pub shared_blur: HashMap<String, crate::render::SharedBlur>,
     pub shadow_cache: HashMap<ObjectId, ShadowCacheEntry>,
     pub border_cache: HashMap<ObjectId, BorderCacheEntry>,
     /// One element per output for the configured background (shader / tile /
@@ -73,9 +72,7 @@ impl RenderCache {
             blur_bg_fbo: None,
             blur_geometry_generation: 0,
             blur_camera_generation: 0,
-            shared_blur: None,
-            shared_blur_at: None,
-            shared_blur_camera_generation: 0,
+            shared_blur: HashMap::new(),
             shadow_cache: HashMap::new(),
             border_cache: HashMap::new(),
             cached_bg: HashMap::new(),
@@ -118,6 +115,7 @@ impl RenderCache {
     /// of reusing a stale element with the previous geometry.
     pub fn remove_output(&mut self, output_name: &str) {
         self.cached_bg.remove(output_name);
+        self.shared_blur.remove(output_name);
         self.cached_error_bar.remove(output_name);
         self.remove_background_chunks(output_name);
         self.remove_capture_state(output_name);

--- a/src/state/render_cache.rs
+++ b/src/state/render_cache.rs
@@ -31,6 +31,12 @@ pub struct RenderCache {
     pub blur_bg_fbo: Option<(GlesTexture, Size<i32, Physical>)>,
     pub blur_geometry_generation: u64,
     pub blur_camera_generation: u64,
+    /// Shared full-output blurred background for `animate_blur`: ping-pong
+    /// pair, blurred once per refresh and sliced per window, so cost stops
+    /// scaling with the number of blurred windows.
+    pub shared_blur: Option<(GlesTexture, GlesTexture, Size<i32, Physical>)>,
+    pub shared_blur_at: Option<std::time::Instant>,
+    pub shared_blur_camera_generation: u64,
     pub shadow_cache: HashMap<ObjectId, ShadowCacheEntry>,
     pub border_cache: HashMap<ObjectId, BorderCacheEntry>,
     /// One element per output for the configured background (shader / tile /
@@ -67,6 +73,9 @@ impl RenderCache {
             blur_bg_fbo: None,
             blur_geometry_generation: 0,
             blur_camera_generation: 0,
+            shared_blur: None,
+            shared_blur_at: None,
+            shared_blur_camera_generation: 0,
             shadow_cache: HashMap::new(),
             border_cache: HashMap::new(),
             cached_bg: HashMap::new(),


### PR DESCRIPTION
With animate_blur on, every blurred window re-renders the entire scene behind it and re-blurs it, per frame. Cost scales with blurred window count: three frosted terminals over an animated shader measured 87% GPU / 216 W at 3440x1440@144 on NVIDIA. That is why the option ships default-off, but it makes living wallpapers effectively unusable behind frosted windows.

## Fix

Blur the scene background once per refresh into a shared full-output texture and let every blurred window slice its own rect from it. The background render happens once instead of once per window, and the slice is a plain blit. Refreshes are throttled to a new `[effects] animate_blur_fps` (default 20, clamped 1-144): animated wallpapers evolve slowly, so a fraction of the output rate still reads as continuous through frosted glass. Camera moves force a refresh so nothing lags while panning.

The shared slice is only exact when nothing but background lies beneath the window. A window stacked over other windows falls back to the existing per-window path at the same cadence, so lower windows still show in its frost. Static-background behaviour is untouched.

Since the slice comes from a full-screen blur, edge samples see real neighbours: this path has no edge-fade by construction (related: #125, fixed separately in #179; this branch includes that commit).

Measured on the same setup: 36% / 79 W with animate_blur on, vs 33% / 72 W off and 87% / 216 W before. Docs and config.reference.toml updated.