### PR TITLE
Add [background] animate_fps: frame-rate cap for animated shader backgrounds

### DIFF
--- a/config.reference.toml
+++ b/config.reference.toml
@@ -237,6 +237,12 @@
 # # blurrier).
 # cache_budget_mb = 128
 
+# # Frame-rate cap for animated (`u_time`) shader backgrounds. 0 = every output
+# # frame (default). Slow-moving shaders look identical well below the refresh
+# # rate; between ticks the compositor reuses the composited result instead of
+# # re-evaluating the shader, so this directly scales the background's GPU cost.
+# animate_fps = 0
+
 [bindings]
 # # Opt out of built-in default bindings by category, for a clean slate.
 # # Normally your [keybindings]/[mouse]/[gestures] entries merge with the

--- a/docs/config.md
+++ b/docs/config.md
@@ -573,6 +573,12 @@ Default: `128`
 
 Memory ceiling (MB) shared by cache_shader and gigapixel-TIFF wallpapers, with LRU eviction. Raise it for sharper revisits on large / HiDPI displays; lower it on memory-constrained machines (too low just keeps the background blurrier).
 
+### `animate_fps`
+
+Default: `0`
+
+Frame-rate cap for animated (`u_time`) shader backgrounds. 0 = every output frame (default). Slow-moving shaders look identical well below the refresh rate; between ticks the compositor reuses the composited result instead of re-evaluating the shader, so this directly scales the background's GPU cost.
+
 ## `[bindings]`
 
 ### `disable_defaults`

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -163,12 +163,50 @@ pub(crate) fn render_if_needed(data: &mut DriftWm) {
             .any(|c| c.has_pending_bakes());
     if data.redraws_needed.is_empty()
         && !data.has_active_animations()
-        && !data.render.background_is_animated
+        && !data.background_animation_due_any()
         && !data.output_config_dirty
         && data.pending_dpms.is_empty()
         && !any_chunked_pending
         && !data.pending_pointer_resync
     {
+        // A capped animated background still needs a wake-up for its next
+        // tick: no event fires on an idle desktop, and without this the
+        // animation would only advance alongside other redraws (stutter).
+        let fps = data.config.background.animate_fps;
+        let eligible: Vec<String> = data.background_render_eligible_output_names().collect();
+        if data.render.background_is_animated
+            && fps > 0
+            && !data.render.background_tick_armed
+            && !eligible.is_empty()
+        {
+            let interval = Duration::from_secs_f64(1.0 / fps as f64);
+            // Wake for the soonest-due eligible output; stamps are per-output.
+            // A fullscreen/DPMS-off output's stamp goes stale forever once it
+            // stops rendering — excluding it here keeps a long-dead stamp
+            // from collapsing this to the 1ms floor and busy-rescheduling.
+            let elapsed = data
+                .render
+                .background_last_animate
+                .iter()
+                .filter(|(name, _)| eligible.contains(name))
+                .map(|(_, t)| t.elapsed())
+                .max()
+                .unwrap_or(interval);
+            let wait = interval
+                .saturating_sub(elapsed)
+                .max(Duration::from_millis(1));
+            if data
+                .loop_handle
+                .insert_source(Timer::from_duration(wait), |_, _, data: &mut DriftWm| {
+                    data.render.background_tick_armed = false;
+                    render_if_needed(data);
+                    TimeoutAction::Drop
+                })
+                .is_ok()
+            {
+                data.render.background_tick_armed = true;
+            }
+        }
         return;
     }
 
@@ -263,9 +301,8 @@ pub(crate) fn render_if_needed(data: &mut DriftWm) {
         // Fullscreen outputs skip the background entirely, so an animated bg
         // gives them nothing to redraw — marking them just burns battery.
         let dirty: Vec<_> = data
-            .active_outputs
-            .iter()
-            .filter(|o| !data.is_output_fullscreen(o))
+            .background_render_eligible_outputs()
+            .filter(|o| data.background_animation_due(&o.name()))
             .cloned()
             .collect();
         data.redraws_needed.extend(dirty);
@@ -1433,7 +1470,7 @@ fn render_frame(
     };
 
     // Update background element
-    let (camera_moved, zoom_changed) = crate::render::update_background_element(
+    let (camera_moved, zoom_changed, bg_animated) = crate::render::update_background_element(
         data, output, cur_camera, cur_zoom, last_cam, last_zoom,
     );
 
@@ -1449,7 +1486,9 @@ fn render_frame(
     // the background shader advances a frame the stale composited result is reused and
     // the background appears "frozen" inside those windows.
     // Fix: reset buffer ages so every pixel is redrawn from scratch this frame.
-    if data.render.background_is_animated {
+    // Only on frames where the animation actually advanced — between capped
+    // ticks the composited result is intentionally reused.
+    if bg_animated {
         let has_transparent = data.space.elements().any(|w| {
             w.wl_surface()
                 .as_deref()

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -205,9 +205,10 @@ pub fn init_winit(
             };
 
             // --- Update cached background element ---
-            let (camera_moved, zoom_changed) = crate::render::update_background_element(
-                data, &output, cur_camera, cur_zoom, last_cam, last_zoom,
-            );
+            let (camera_moved, zoom_changed, bg_animated) =
+                crate::render::update_background_element(
+                    data, &output, cur_camera, cur_zoom, last_cam, last_zoom,
+                );
 
             // --- Take backend to split borrow from state ---
             let Backend::Winit(mut backend) = data.backend.take().unwrap() else {
@@ -231,7 +232,7 @@ pub fn init_winit(
             // Force full redraw when animated background is visible through transparent windows.
             // Without this, buffer-age optimisation reuses the stale composited result for
             // transparent windows — the background appears frozen inside them.
-            if age > 0 && data.render.background_is_animated {
+            if age > 0 && bg_animated {
                 let has_transparent = data.space.elements().any(|w| {
                     w.wl_surface()
                         .as_deref()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -509,6 +509,7 @@ impl Config {
             cache_shader: raw.background.cache_shader.unwrap_or(false),
             transparent_shader: raw.background.transparent_shader.unwrap_or(false),
             cache_budget_mb: raw.background.cache_budget_mb.unwrap_or(128),
+            animate_fps: raw.background.animate_fps.unwrap_or(0).min(1000),
             kind: resolve_background_kind(raw.background, &mut errors),
         };
 
@@ -997,6 +998,7 @@ fn resolve_background_kind(
         cache_shader: _,
         transparent_shader: _,
         cache_budget_mb: _,
+        animate_fps: _,
     } = raw;
     let texture = texture.as_deref().map(expand_tilde);
     if let Some(t) = kind.as_deref() {

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -201,6 +201,7 @@ pub(super) struct BackgroundFileConfig {
     pub cache_shader: Option<bool>,
     pub transparent_shader: Option<bool>,
     pub cache_budget_mb: Option<u32>,
+    pub animate_fps: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1017,4 +1017,9 @@ pub struct BackgroundConfig {
     /// shader-bake cache (`cache_shader`) and gigapixel-TIFF wallpapers. The
     /// cache LRU-evicts to stay under this; lower it on low-memory machines.
     pub cache_budget_mb: u32,
+    /// Frame-rate cap for animated (`u_time`) background shaders. 0 = every
+    /// output frame (default). Slow-moving shaders look identical well below
+    /// the refresh rate, and between animation ticks the compositor reuses the
+    /// composited result instead of re-evaluating the shader.
+    pub animate_fps: u32,
 }

--- a/src/render/background.rs
+++ b/src/render/background.rs
@@ -168,7 +168,10 @@ impl BackgroundElement {
 }
 
 /// Update the cached background element for the current camera/zoom.
-/// Returns (camera_moved, zoom_changed) for the caller's damage logic.
+/// Returns (camera_moved, zoom_changed, animated) for the caller's damage
+/// logic. `animated` reports whether this call advanced the animation —
+/// callers can't re-check `background_animation_due` afterwards because the
+/// stamp below has already consumed the tick.
 pub fn update_background_element(
     state: &mut crate::state::DriftWm,
     output: &Output,
@@ -176,7 +179,7 @@ pub fn update_background_element(
     cur_zoom: f64,
     last_rendered_camera: Point<f64, Logical>,
     last_rendered_zoom: f64,
-) -> (bool, bool) {
+) -> (bool, bool, bool) {
     let camera_moved = cur_camera != last_rendered_camera;
     let zoom_changed = cur_zoom != last_rendered_zoom;
     let output_name = output.name();
@@ -188,9 +191,19 @@ pub fn update_background_element(
     // Only push uniforms the shader actually consumes — update_uniforms bumps
     // the element's CommitCounter, which would damage the full-screen bg every
     // frame and force re-composition of every element above (blur especially).
+    // Animated shaders advance only when their fps budget allows; between
+    // ticks the CommitCounter stays put and the compositor reuses the last
+    // composited result instead of re-evaluating the shader every frame.
+    let animate_due = state.background_animation_due(&output_name);
+    if animate_due {
+        state
+            .render
+            .background_last_animate
+            .insert(output_name.clone(), std::time::Instant::now());
+    }
     let uniforms_stale = (camera_moved && state.render.background_uses_camera)
         || (zoom_changed && state.render.background_uses_zoom)
-        || state.render.background_is_animated;
+        || animate_due;
 
     let frame = BgFrame {
         canvas_area,
@@ -207,7 +220,7 @@ pub fn update_background_element(
     if let Some(bg) = state.render.cached_bg.get_mut(&output_name) {
         bg.update(&frame);
     }
-    (camera_moved, zoom_changed)
+    (camera_moved, zoom_changed, animate_due)
 }
 
 /// Compile background shader and/or load tile/wallpaper image.

--- a/src/render/blur.rs
+++ b/src/render/blur.rs
@@ -435,9 +435,21 @@ pub(crate) fn process_blur_requests(
         }
         if let Some(mut shared) = state.render.shared_blur.remove(&output_name) {
             let camera_moved = shared.camera_generation != camera_gen;
-            let due = shared
+            let time_due = shared
                 .refreshed_at
                 .is_none_or(|at| at.elapsed() >= min_interval);
+            // Also require the background to have actually ticked since the
+            // blur's last refresh: animate_blur_fps is independent of
+            // [background] animate_fps, so without this a faster blur
+            // throttle re-samples and re-blurs an unchanged background.
+            let bg_ticked_since_refresh = match (
+                state.render.background_last_animate.get(&output_name),
+                shared.refreshed_at,
+            ) {
+                (Some(bg_t), Some(blur_t)) => *bg_t > blur_t,
+                _ => true,
+            };
+            let due = time_due && bg_ticked_since_refresh;
             if due || camera_moved {
                 let mut rendered = false;
                 if let Ok(mut target) = renderer.bind(&mut shared.tex_a) {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1155,6 +1155,55 @@ impl DriftWm {
             || os.momentum.velocity.y != 0.0
     }
 
+    /// True when `output_name`'s animated background is due for its next tick
+    /// under `[background] animate_fps` (0 = every frame). The timestamp is
+    /// stamped where the uniforms are actually pushed, in
+    /// `update_background_element`. Keyed per output: outputs render on their
+    /// own vblanks, and a global stamp would let whichever renders first
+    /// satisfy the interval and starve the rest.
+    pub fn background_animation_due(&self, output_name: &str) -> bool {
+        if !self.render.background_is_animated {
+            return false;
+        }
+        let fps = self.config.background.animate_fps;
+        if fps == 0 {
+            return true;
+        }
+        self.render
+            .background_last_animate
+            .get(output_name)
+            .is_none_or(|t| t.elapsed() >= std::time::Duration::from_secs_f64(1.0 / fps as f64))
+    }
+
+    /// Outputs whose animated background can actually render: active and not
+    /// fullscreen (fullscreen skips the background entirely, so it never
+    /// stamps `background_last_animate` and would otherwise look permanently
+    /// due). Shared by the idle due-check, the tick-timer arming wait, and
+    /// the per-frame dirty-marking so all three agree on which outputs count.
+    pub(crate) fn background_render_eligible_outputs(&self) -> impl Iterator<Item = &Output> {
+        self.active_outputs
+            .iter()
+            .filter(|o| !self.is_output_fullscreen(o))
+    }
+
+    /// Owned-name variant of [`Self::background_render_eligible_outputs`] for
+    /// callers outside this module that need to filter a name-keyed map
+    /// (e.g. `background_last_animate`) without holding a borrow of `self`.
+    pub fn background_render_eligible_output_names(&self) -> impl Iterator<Item = String> + '_ {
+        self.background_render_eligible_outputs().map(|o| o.name())
+    }
+
+    /// True when any eligible output's animated background is due (idle
+    /// wake-up check). Restricted to outputs that actually render the
+    /// background — a DPMS-off or fullscreen output never gets a
+    /// `background_last_animate` stamp, so including it here would read as
+    /// permanently due and defeat the idle fast path (see
+    /// `background_render_eligible_outputs`).
+    pub fn background_animation_due_any(&self) -> bool {
+        self.background_render_eligible_outputs()
+            .any(|o| self.background_animation_due(&o.name()))
+    }
+
     pub fn has_active_animations(&self) -> bool {
         self.space
             .outputs()

--- a/src/state/render_cache.rs
+++ b/src/state/render_cache.rs
@@ -42,6 +42,14 @@ pub struct RenderCache {
     /// scaling with the number of blurred windows. Keyed by output name —
     /// outputs differ in size and render on their own vblanks.
     pub shared_blur: HashMap<String, crate::render::SharedBlur>,
+    /// Per-output timestamp of the last animated-background uniform push
+    /// ([background] animate_fps). Keyed by output name: a single global
+    /// stamp would let one output's render satisfy the interval and starve
+    /// the others on multi-monitor setups.
+    pub background_last_animate: HashMap<String, std::time::Instant>,
+    /// A one-shot tick timer is armed for the next animation frame. Without
+    /// it the capped animation only advances alongside other redraws.
+    pub background_tick_armed: bool,
     pub shadow_cache: HashMap<ObjectId, ShadowCacheEntry>,
     pub border_cache: HashMap<ObjectId, BorderCacheEntry>,
     /// One element per output for the configured background (shader / tile /
@@ -79,6 +87,8 @@ impl RenderCache {
             blur_geometry_generation: 0,
             blur_camera_generation: HashMap::new(),
             shared_blur: HashMap::new(),
+            background_last_animate: HashMap::new(),
+            background_tick_armed: false,
             shadow_cache: HashMap::new(),
             border_cache: HashMap::new(),
             cached_bg: HashMap::new(),
@@ -124,6 +134,7 @@ impl RenderCache {
         self.shared_blur.remove(output_name);
         self.blur_cache.retain(|(out, _), _| out != output_name);
         self.blur_camera_generation.remove(output_name);
+        self.background_last_animate.remove(output_name);
         self.cached_error_bar.remove(output_name);
         self.remove_background_chunks(output_name);
         self.remove_capture_state(output_name);


### PR DESCRIPTION
An animated (u_time) background shader runs at the full output rate: uniforms are pushed every frame, the CommitCounter bumps, and the whole screen redraws 144 times a second. With transparent windows on top, the buffer-age reset turns even partial damage into full-screen redraws. A slow-moving shader burns most of a GPU to look exactly like its 30 fps self: measured 37% GPU / 79 W idle at 3440x1440@144 on NVIDIA, fans never idle.

## Fix

New `[background] animate_fps` (default 0 = current behaviour). Animated uniforms are pushed only when the fps budget allows; between ticks the CommitCounter stays put and the compositor reuses the composited result, the same economics static shaders already enjoy. The render-loop keepalive, the per-frame dirty marking and the transparent-window buffer-age reset are gated on the same due-check so nothing else forces full-rate redraws. Camera and zoom pushes are untouched, so panning and zooming stay at full refresh.

Measured with the same shader at `animate_fps = 30`: 17% GPU / 64 W, visually identical. Docs and config.reference.toml updated, config.md regenerated via the docs test.