### PR TITLE
Add wheel-up/wheel-down mouse triggers: any action, once per notch

### DIFF
--- a/config.reference.toml
+++ b/config.reference.toml
@@ -363,7 +363,9 @@
 # # Context-aware: on-window, on-canvas, anywhere.
 # # Specific context checked first, then "anywhere" as fallback.
 # # Click-to-focus and SSD decoration clicks are always hardcoded.
-# # Triggers: left, right, middle (buttons), trackpad-scroll, wheel-scroll
+# # Triggers: left, right, middle (buttons), trackpad-scroll, wheel-scroll,
+# # wheel-up, wheel-down. The wheel-up/wheel-down triggers fire once per
+# # discrete wheel notch and can run any action, e.g. volume on mod+shift+scroll.
 # # Merges with defaults. Use "none" to unbind.
 # #
 # # Mouse actions: move-window, move-snapped-windows, resize-window,

--- a/docs/config.md
+++ b/docs/config.md
@@ -713,7 +713,7 @@ Default: `false`
 
 When true, maximize/unmaximize initiated via window decoration (CSD maximize button, SSD title-bar double-click, or xdg/foreign-toplevel set_maximized) propagates to every window connected via snap adjacency. Keybinding/gesture fit is unaffected — bind `fit-window-snapped` explicitly if you want cluster-aware fit there too.
 
-Mouse bindings: "Modifier+...+Trigger" = "action" Context-aware: on-window, on-canvas, anywhere. Specific context checked first, then "anywhere" as fallback. Click-to-focus and SSD decoration clicks are always hardcoded. Triggers: left, right, middle (buttons), trackpad-scroll, wheel-scroll Merges with defaults. Use "none" to unbind.
+Mouse bindings: "Modifier+...+Trigger" = "action" Context-aware: on-window, on-canvas, anywhere. Specific context checked first, then "anywhere" as fallback. Click-to-focus and SSD decoration clicks are always hardcoded. Triggers: left, right, middle (buttons), trackpad-scroll, wheel-scroll, wheel-up, wheel-down. The wheel-up/wheel-down triggers fire once per discrete wheel notch and can run any action, e.g. volume on mod+shift+scroll. Merges with defaults. Use "none" to unbind.
 
 Mouse actions: move-window, move-snapped-windows, resize-window, resize-window-snapped, pan-viewport, zoom, center-nearest Any keyboard action also works for button triggers: exec, close-window, toggle-fullscreen, etc.
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -185,6 +185,24 @@ impl Config {
         self.mouse.lookup(&binding, context)
     }
 
+    /// Look up a discrete wheel-notch action (wheel-up / wheel-down).
+    pub fn mouse_wheel_step_lookup_ctx(
+        &self,
+        modifiers: &ModifiersState,
+        up: bool,
+        context: BindingContext,
+    ) -> Option<&MouseAction> {
+        let binding = MouseBinding {
+            modifiers: Modifiers::from_state(modifiers),
+            trigger: if up {
+                MouseTrigger::WheelUp
+            } else {
+                MouseTrigger::WheelDown
+            },
+        };
+        self.mouse.lookup(&binding, context)
+    }
+
     /// Look up a mouse scroll action by modifier state, axis source, and context.
     pub fn mouse_scroll_lookup_ctx(
         &self,

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -83,6 +83,8 @@ pub fn parse_mouse_binding(s: &str, mod_key: ModKey) -> Result<MouseBinding, Str
         "middle" => MouseTrigger::Button(BTN_MIDDLE),
         "trackpad-scroll" => MouseTrigger::TrackpadScroll,
         "wheel-scroll" => MouseTrigger::WheelScroll,
+        "wheel-up" => MouseTrigger::WheelUp,
+        "wheel-down" => MouseTrigger::WheelDown,
         other => return Err(format!("unknown mouse trigger: {other}")),
     };
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -221,6 +221,11 @@ pub enum MouseTrigger {
     Button(u32),
     TrackpadScroll,
     WheelScroll,
+    /// One discrete wheel notch away from the user. Unlike WheelScroll
+    /// (continuous pan/zoom), notch triggers can run any Action.
+    WheelUp,
+    /// One discrete wheel notch toward the user.
+    WheelDown,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/input/pointer.rs
+++ b/src/input/pointer.rs
@@ -774,6 +774,51 @@ impl DriftWm {
         let pos = pointer.current_location();
         let source = event.source();
 
+        // Discrete wheel-notch bindings (wheel-up / wheel-down) run any
+        // action once per notch — volume on mod+shift+scroll and the like.
+        // Wheel sources only: finger and continuous scrolling have no
+        // notches. Checked before the fullscreen block so a notch action
+        // fires like a keybinding, without exiting fullscreen.
+        if matches!(source, AxisSource::Wheel | AxisSource::WheelTilt) {
+            let v = event
+                .amount_v120(Axis::Vertical)
+                .map(|v| v / 120.0)
+                .or_else(|| event.amount(Axis::Vertical).map(|v| v / 15.0))
+                .unwrap_or(0.0);
+            let notch_context = if self.is_fullscreen() {
+                // The fullscreen window fills the screen.
+                BindingContext::OnWindow
+            } else {
+                self.pointer_context(pos)
+            };
+            if v != 0.0
+                && let Some(MouseAction::Action(act)) = self
+                    .config
+                    .mouse_wheel_step_lookup_ctx(&mods, v < 0.0, notch_context)
+                    .cloned()
+            {
+                // High-resolution wheels emit sub-notch v120 deltas;
+                // accumulate to whole notches so a flick fires the action
+                // once per notch, not once per event.
+                if self.wheel_notch_accum != 0.0 && self.wheel_notch_accum.signum() != v.signum() {
+                    self.wheel_notch_accum = 0.0;
+                }
+                self.wheel_notch_accum += v;
+                let whole = self.wheel_notch_accum.abs().floor();
+                self.wheel_notch_accum -= self.wheel_notch_accum.signum() * whole;
+                let notches = (whole as u32).min(10);
+                for _ in 0..notches {
+                    self.execute_action(&act);
+                }
+                // Consume sub-notch events too — the binding owns this
+                // scroll; forwarding the fractions would double-handle it.
+                let frame = AxisFrame::new(Event::time_msec(&event));
+                pointer.axis(self, frame);
+                pointer.frame(self);
+                return;
+            }
+        }
+
         // During fullscreen: bound scroll exits fullscreen first; plain scroll forwards.
         if self.is_fullscreen() {
             if self

--- a/src/state/init.rs
+++ b/src/state/init.rs
@@ -328,6 +328,7 @@ impl DriftWm {
             on_demand_layer: None,
             popup_grab: None,
             held_action: None,
+            wheel_notch_accum: 0.0,
             tap: TapTracker::default(),
             pending_tap_action: None,
             suppressed_keys: HashSet::new(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -512,6 +512,12 @@ pub struct DriftWm {
 
     pub held_action: Option<(u32, driftwm::config::Action, Instant)>,
 
+    /// Fractional wheel-notch credit for wheel-up/wheel-down bindings.
+    /// High-resolution wheels emit sub-notch v120 deltas; they accumulate
+    /// here and the bound action fires once per whole notch. Direction
+    /// flips discard the residual.
+    pub wheel_notch_accum: f64,
+
     pub tap: TapTracker,
     /// Action queued by a completed tap chord, run after the closure forwards
     /// the modifier events so the focused client still sees them.


### PR DESCRIPTION
Scroll bindings only drive the continuous mouse actions (pan-viewport, zoom): they fire per event with no up/down distinction, so a wheel notch can't run a command. Buttons can run any action; the wheel can't.

## Fix

Two new mouse trigger forms, `wheel-up` and `wheel-down`. They match discrete notches (amount_v120 when the backend provides it, amount/15 fallback), run any bound action once per notch (capped at 10 per event burst), and consume the event so the client doesn't also scroll. Finger scrolling is untouched: notches are a wheel concept, trackpads stay continuous.

Motivating setup:

```toml
[mouse.anywhere]
"mod+shift+wheel-up" = "spawn wpctl set-volume -l 1.0 @DEFAULT_AUDIO_SINK@ 1%+"
"mod+shift+wheel-down" = "spawn wpctl set-volume @DEFAULT_AUDIO_SINK@ 1%-"
```

Volume on a scroll chord, and whatever OSD watches the mixer shows up for free.

Stacks on #185 (shared branch history). config.reference.toml updated, config.md regenerated via the docs test.