### PR TITLE
Add left_handed mouse config option

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -540,6 +540,7 @@ impl Config {
                 ),
                 accel_profile,
                 natural_scroll: m.natural_scroll.unwrap_or(false),
+                left_handed: m.left_handed.unwrap_or(false),
             }
         };
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -87,6 +87,7 @@ pub(super) struct MouseDeviceFileConfig {
     pub accel_speed: Option<f64>,
     pub accel_profile: Option<String>,
     pub natural_scroll: Option<bool>,
+    pub left_handed: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -395,6 +395,7 @@ pub struct MouseDeviceSettings {
     pub accel_speed: f64,
     pub accel_profile: AccelProfile,
     pub natural_scroll: bool,
+    pub left_handed: bool,
 }
 
 impl Default for MouseDeviceSettings {
@@ -403,6 +404,7 @@ impl Default for MouseDeviceSettings {
             accel_speed: 0.0,
             accel_profile: AccelProfile::Flat,
             natural_scroll: false,
+            left_handed: false,
         }
     }
 }

--- a/src/input/gestures/device_config.rs
+++ b/src/input/gestures/device_config.rs
@@ -88,11 +88,12 @@ impl DriftWm {
     fn configure_mouse(&self, device: &mut smithay::reexports::input::Device) {
         let cfg = &self.config.mouse_device;
         tracing::info!(
-            "Configuring mouse: {} (accel={}, profile={:?}, natural_scroll={})",
+            "Configuring mouse: {} (accel={}, profile={:?}, natural_scroll={}, left_handed={})",
             device.name(),
             cfg.accel_speed,
             cfg.accel_profile,
             cfg.natural_scroll,
+            cfg.left_handed,
         );
 
         if let Err(e) = device.config_accel_set_speed(cfg.accel_speed) {
@@ -101,6 +102,11 @@ impl DriftWm {
         set_accel_profile(device, cfg.accel_profile);
         if let Err(e) = device.config_scroll_set_natural_scroll_enabled(cfg.natural_scroll) {
             tracing::warn!("Failed to set mouse natural_scroll: {e:?}");
+        }
+        if device.config_left_handed_is_available()
+            && let Err(e) = device.config_left_handed_set(cfg.left_handed)
+        {
+            tracing::warn!("Failed to set mouse left_handed: {e:?}");
         }
     }
 }


### PR DESCRIPTION
## What

Adds a `left_handed` option under `[input.mouse]` that swaps left/right mouse buttons.

```toml
[input.mouse]
left_handed = true
```

## Why

libinput already exposes `config_left_handed_set()` for this — the same category of per-device libinput config as `natural_scroll`, which the mouse config already wires up via `config_scroll_set_natural_scroll_enabled()`. There was no equivalent for left-handed use, so this follows the exact same pattern end-to-end:

- `config/toml.rs` — raw `left_handed: Option<bool>` field
- `config/mod.rs` — resolves to `unwrap_or(false)`
- `config/types.rs` — `MouseDeviceSettings.left_handed: bool`
- `input/gestures/device_config.rs` — applies via `device.config_left_handed_set()`, gated on `config_left_handed_is_available()` since not all pointing devices support it

## Testing

Built and ran on real hardware (Fedora, udev backend), confirmed left/right click are swapped with `left_handed = true` set.

`cargo fmt --check` and `cargo clippy --release` both clean.