### PR TITLE
Focus windows opened with pinned_to_screen

### DIFF
--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -543,7 +543,6 @@ impl CompositorHandler for DriftWm {
                             && !is_fullscreen
                             && !place_in_background
                             && !deferred_fit_or_fs
-                            && !self.stage.is_pinned(&window)
                         {
                             let reset = self.config.zoom_reset_on_new_window;
                             // Cursor mode is "stay put" by default; only
@@ -551,7 +550,9 @@ impl CompositorHandler for DriftWm {
                             // zoomed out and asked for reset).
                             let cursor_overview_rescue =
                                 placed_at_cursor && reset && self.zoom() < 1.0 - 1e-9;
-                            if placed_at_cursor && !cursor_overview_rescue {
+                            if self.stage.is_pinned(&window)
+                                || placed_at_cursor && !cursor_overview_rescue
+                            {
                                 let serial = smithay::utils::SERIAL_COUNTER.next_serial();
                                 self.raise_and_focus(&window, serial);
                             } else {

--- a/src/tests/window_rules.rs
+++ b/src/tests/window_rules.rs
@@ -41,9 +41,11 @@ size = [320, 240]
     f.add_output(1, (1920, 1080));
     let id = f.add_client();
 
+    map_window(&mut f, id, "normal", (400, 300));
     map_window(&mut f, id, "pin", (320, 240));
     let window = window_by_app_id(&mut f, "pin").unwrap();
 
+    assert_eq!(keyboard_focus(&mut f), Some(server_surface(&window)));
     let site = f.state().stage.pin_of(&window).cloned().unwrap();
     assert_eq!(site.output, "HEADLESS-1");
     // No rule `position` means output center: screen top-left =


### PR DESCRIPTION
Previously, when a window was opened with the **pinned_to_screen = true** property set through an application's **[[window_rules]]**, the compositor did not automatically focus it

This PR changes that behavior so that newly opened windows matching a pinned_to_screen rule receive focus automatically, consistent with regular newly opened windows