### PR TITLE
fix incorrect use of window_bbox instead of window_bbox_with_popups

### DIFF
--- a/dev/docs/caveats.md
+++ b/dev/docs/caveats.md
@@ -4,7 +4,7 @@ Things to keep in mind as the codebase grows.
 
 ## Never touch `Space` directly — go through the stage
 
-The stage (`src/stage/`) is the source of truth for the window list, z-order, positions, focus history, fullscreen membership, pin-to-screen membership, and fit state. Read window state from it (`stage.windows()`, `stage.position_of`, `DriftWm::element_under` / `window_bbox`); mutate through `DriftWm::map_window` / `raise_window` / `unmap_window` and the stage-backed methods. `Space` holds no window elements at all — it survives only as the output registry (`map_output` / `outputs` / `output_geometry`). A clippy `disallowed-methods` lint (see `clippy.toml`) rejects every `Space` element API (reads *and* writes) and `Space::refresh`, and debug builds run `verify_stage_invariants` every frame in `post_render` — a panic there means a mutation bypassed the wrappers.
+The stage (`src/stage/`) is the source of truth for the window list, z-order, positions, focus history, fullscreen membership, pin-to-screen membership, and fit state. Read window state from it (`stage.windows()`, `stage.position_of`, `DriftWm::element_under` / `window_bbox_with_popups`); mutate through `DriftWm::map_window` / `raise_window` / `unmap_window` and the stage-backed methods. `Space` holds no window elements at all — it survives only as the output registry (`map_output` / `outputs` / `output_geometry`). A clippy `disallowed-methods` lint (see `clippy.toml`) rejects every `Space` element API (reads *and* writes) and `Space::refresh`, and debug builds run `verify_stage_invariants` every frame in `post_render` — a panic there means a mutation bypassed the wrappers.
 
 Per-window output membership (`wl_surface.enter`/`leave`) is driven by `DriftWm::refresh_window_outputs`, not by `Space`: fullscreen windows belong only to their home output, pinned windows only to their pin target, and virtual placeholder outputs (dead `wl_output` global) are never entered. New enter/leave paths must route through it — membership sent from anywhere else reintroduces the multi-output fullscreen leak (a game unfullscreens when another output's camera pans over its parked window).
 
@@ -69,3 +69,9 @@ driftwm doesn't embed XWayland directly. X11 apps reach the compositor via [`xwa
 ## What to test where
 
 Smithay glue code (handlers, delegates) is not worth unit testing — it's framework boilerplate. Pure logic (canvas math, config parsing, gesture/binding resolution) gets unit tests; stage policy gets the proptest harness; the protocol↔policy wiring gets the in-process headless fixture (`src/tests/`), where a real `DriftWm` serves real wayland clients with no display. The full map and the testing rules live in [testing.md](testing.md).
+
+## Smithay Bounding Boxes (Popups and Subsurfaces)
+
+When working with `smithay::desktop::Window`, **never** use the inherent `window.bbox()` method for hit-testing, damage tracking, or rendering bounds checks. The inherent method only calculates the bounding box of the main toplevel window and completely ignores any popups or subsurfaces. 
+
+Always use `window.bbox_with_popups()` (or our internal wrapper `window_bbox_with_popups(window)` in `src/state/mod.rs`). Failing to do so will cause overhanging popups to be clipped at monitor boundaries, suffer from severe frame-throttling, or instantly lose focus when hovered.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -882,7 +882,7 @@ impl DriftWm {
             .rev()
             .filter(|w| !skip(w))
             .filter(|w| {
-                self.window_bbox(w)
+                self.window_bbox_with_popups(w)
                     .is_some_and(|bbox| bbox.to_f64().contains(point))
             })
             .find_map(|w| {

--- a/src/render/lifecycle.rs
+++ b/src/render/lifecycle.rs
@@ -210,7 +210,7 @@ pub fn post_render(state: &mut crate::state::DriftWm, output: &Output) {
             continue;
         };
         let geom_loc = window.geometry().loc;
-        let mut bbox = window.bbox();
+        let mut bbox = window.bbox_with_popups();
         bbox.loc += loc - geom_loc;
         let on_screen = visible_rect.overlaps(bbox);
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -255,7 +255,7 @@ pub(crate) fn compose_capture_elements(
                 &state.config.decorations,
             );
 
-        let mut bbox = window.bbox();
+        let mut bbox = window.bbox_with_popups();
         bbox.loc += loc - geom_loc;
         if has_ssd {
             let r = driftwm::config::DecorationConfig::SHADOW_RADIUS.ceil() as i32;
@@ -683,7 +683,7 @@ pub fn compose_frame(
                 &state.config.decorations,
             );
 
-        let mut bbox = window.bbox();
+        let mut bbox = window.bbox_with_popups();
         bbox.loc += loc - geom_loc;
         if has_ssd {
             let r = driftwm::config::DecorationConfig::SHADOW_RADIUS.ceil() as i32;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1217,7 +1217,7 @@ impl DriftWm {
         let outputs: Vec<Output> = self.space.outputs().cloned().collect();
 
         if let Some(window) = self.window_for_surface(&root)
-            && let Some(win_bbox) = self.window_bbox(&window)
+            && let Some(win_bbox) = self.window_bbox_with_popups(&window)
         {
             // Use zoom-aware visible canvas rect rather than
             // `Space::outputs_for_element`: the latter is built on the cached
@@ -1454,15 +1454,15 @@ impl DriftWm {
         found.or_else(|| self.active_output())
     }
 
-    /// Bounding box of a mapped window in canvas coordinates: `window.bbox()`
+    /// Bounding box of a mapped window in canvas coordinates: `window.bbox_with_popups()`
     /// (which includes popup/subsurface overhang) placed at the stage position.
     /// Mirrors `Space::element_bbox`.
-    pub(crate) fn window_bbox(
+    pub(crate) fn window_bbox_with_popups(
         &self,
         window: &Window,
     ) -> Option<smithay::utils::Rectangle<i32, Logical>> {
         let pos = self.stage.position_of(window)?;
-        let mut bbox = window.bbox();
+        let mut bbox = window.bbox_with_popups();
         bbox.loc += pos - window.geometry().loc;
         Some(bbox)
     }


### PR DESCRIPTION
I noticed this issue when hovering over popups that are over another window - gtk closes them because the compositor focuses the window behind.

Tested fixes:
- Use window_bbox_with_popups instead of window.bbox() for detecting what's under the cursor; now popups work correctly and retain focus.
- Changed the method naming and documentation across the codebase because it was misleading and incorrect regarding its handling of popups.

Untested fixes:
- Fixed rendering visibility checks (`visible_rect.overlaps`) and frame callback throttling to use `window.bbox_with_popups()`. This resolves a hidden multi-monitor edge case where popups overhanging across screen boundaries would be visually clipped and suffer from severe frame throttling.
- Fixed `mark_dirty_for_surface` to correctly include overhanging popups when calculating which outputs need redrawing, preventing popups from visually freezing on adjacent monitors.

**(It just makes sense but i don't have a second monitor to test it, it would be really good to test for issues before and after the change)**

Holy vibe and slop! Is it Claude to blame? There's literally a comment describing that the method checks for windows and popups, and then it uses a method that doesn't include them. Its code should always be questioned.

I added the instruction to the caveats.md, i hope Claude reads it.