### PR TITLE
Fix animate_blur cost scaling with window count: slice on actual overlap, throttle pan refreshes

### DIFF
--- a/src/render/blur.rs
+++ b/src/render/blur.rs
@@ -514,6 +514,26 @@ pub(crate) fn process_blur_requests(
 
     // ── First pass: create/resize caches, update dirty flags, decide who recomputes ──
     let pad = blur_pad(blur_strength, blur_passes);
+
+    // behind_starts alone is a z-order test: side-by-side windows all read as
+    // "stacked" and lose the shared slice. Fall through only when an element
+    // below this window (padded by the blur reach) actually intersects it.
+    let elem_scale = smithay::utils::Scale::from(output_scale);
+    let occluded_by_lower: Vec<bool> = blur_requests
+        .iter()
+        .enumerate()
+        .map(|(i, req)| {
+            let mut probe = req.screen_rect;
+            probe.loc.x -= pad;
+            probe.loc.y -= pad;
+            probe.size.w += 2 * pad;
+            probe.size.h += 2 * pad;
+            let start = behind_starts[i].min(background_start);
+            all_elements[start..background_start]
+                .iter()
+                .any(|e| e.geometry(elem_scale).overlaps(probe))
+        })
+        .collect();
     let mut needs_recompute: Vec<bool> = Vec::with_capacity(blur_requests.len());
     let mut mask_forced: Vec<bool> = Vec::with_capacity(blur_requests.len());
     for (i, req) in blur_requests.iter().enumerate() {
@@ -589,14 +609,14 @@ pub(crate) fn process_blur_requests(
         };
 
         // The shared slice is only exact when nothing but scene background
-        // lies beneath this window; a window stacked over other windows
-        // falls through to the per-window path (throttled by the same
+        // lies beneath this window; a window that actually overlaps a lower
+        // one falls through to the per-window path (throttled by the same
         // shared_refreshed cadence), so lower windows show in its frost.
         // Missing shared textures (GL alloc failure) also fall through —
         // skipping would insert this window's never-rendered texture as an
         // invisible blur.
         if animated_bg
-            && behind_starts[i] >= background_start
+            && !occluded_by_lower[i]
             && let Some(shared) = state.render.shared_blur.get(&output_name)
         {
             // Slice this window's rect out of the shared blurred background.

--- a/src/render/blur.rs
+++ b/src/render/blur.rs
@@ -462,8 +462,11 @@ pub(crate) fn process_blur_requests(
                 (Some(bg_t), Some(blur_t)) => *bg_t > blur_t,
                 _ => true,
             };
-            let due = time_due && bg_ticked_since_refresh;
-            if due || camera_moved {
+            // Camera moves force a refresh but stay inside the throttle: at
+            // frame rate a pan would run a full scene render + full-output
+            // blur per frame, which is most of the pan heat.
+            let due = time_due && (bg_ticked_since_refresh || camera_moved);
+            if due {
                 let mut rendered = false;
                 if let Ok(mut target) = renderer.bind(&mut shared.tex_a) {
                     let mut dt =
@@ -573,6 +576,22 @@ pub(crate) fn process_blur_requests(
             req.layer,
             BlurLayer::Overlay | BlurLayer::Top | BlurLayer::Pinned
         ) && cache.last_camera_generation != camera_gen;
+
+        // Hold occluded windows while a pan is in flight: their recompute is
+        // a scene re-render, and the moving screen rect churns the background
+        // hash every frame. Markers stay unconsumed so the pending change
+        // fires once on settle. Canvas windows pan together with their
+        // backdrop, so the held frost stays visually correct meanwhile.
+        let pan_in_flight = state
+            .render
+            .blur_camera_moved_at
+            .get(&output_name)
+            .is_some_and(|t| t.elapsed() < std::time::Duration::from_millis(150));
+        if animated_bg && occluded_by_lower[i] && pan_in_flight && cache.force_dirty_frames == 0 {
+            mask_forced.push(false);
+            needs_recompute.push(false);
+            continue;
+        }
 
         // Occluded windows are excluded from the animated cadence: their
         // frost re-renders the scene behind them, so refreshing N stacked

--- a/src/render/blur.rs
+++ b/src/render/blur.rs
@@ -574,7 +574,15 @@ pub(crate) fn process_blur_requests(
             BlurLayer::Overlay | BlurLayer::Top | BlurLayer::Pinned
         ) && cache.last_camera_generation != camera_gen;
 
-        if background_changed || geom_changed || camera_dirty || (animated_bg && shared_refreshed) {
+        // Occluded windows are excluded from the animated cadence: their
+        // frost re-renders the scene behind them, so refreshing N stacked
+        // windows costs N scene renders per tick and heat scales with window
+        // count. Their frost stays static between camera/geometry changes.
+        if background_changed
+            || geom_changed
+            || camera_dirty
+            || (animated_bg && shared_refreshed && !occluded_by_lower[i])
+        {
             cache.dirty = true;
         }
         mask_forced.push(cache.force_dirty_frames > 0);

--- a/src/render/blur.rs
+++ b/src/render/blur.rs
@@ -559,7 +559,8 @@ pub(crate) fn process_blur_requests(
             }
         }
         let cache = state.render.blur_cache.get_mut(&key).unwrap();
-        if cache.size != win_size || cache.pad_size != pad_size {
+        let resized = cache.size != win_size || cache.pad_size != pad_size;
+        if resized {
             cache.resize(renderer, win_size, pad_size);
         }
 
@@ -587,7 +588,13 @@ pub(crate) fn process_blur_requests(
             .blur_camera_moved_at
             .get(&output_name)
             .is_some_and(|t| t.elapsed() < std::time::Duration::from_millis(150));
-        if animated_bg && occluded_by_lower[i] && pan_in_flight && cache.force_dirty_frames == 0 {
+        if animated_bg
+            && occluded_by_lower[i]
+            && pan_in_flight
+            && !resized
+            && !camera_dirty
+            && cache.force_dirty_frames == 0
+        {
             mask_forced.push(false);
             needs_recompute.push(false);
             continue;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1668,6 +1668,9 @@ impl DriftWm {
                     .blur_camera_generation
                     .entry(output.name())
                     .or_insert(0) += 1;
+                self.render
+                    .blur_camera_moved_at
+                    .insert(output.name(), std::time::Instant::now());
             }
             self.space.map_output(&output, cam);
         }

--- a/src/state/render_cache.rs
+++ b/src/state/render_cache.rs
@@ -37,6 +37,9 @@ pub struct RenderCache {
     /// output's pan force every other output's blur to refresh (bypassing the
     /// animate_blur_fps throttle) even though their cameras never moved.
     pub blur_camera_generation: HashMap<String, u64>,
+    /// When the camera last moved, per output. Occluded windows hold their
+    /// blur recomputes while a pan is in flight and catch up on settle.
+    pub blur_camera_moved_at: HashMap<String, std::time::Instant>,
     /// Shared full-output blurred background for `animate_blur`: ping-pong
     /// pair, blurred once per refresh and sliced per window, so cost stops
     /// scaling with the number of blurred windows. Keyed by output name —
@@ -86,6 +89,7 @@ impl RenderCache {
             blur_bg_fbo: None,
             blur_geometry_generation: 0,
             blur_camera_generation: HashMap::new(),
+            blur_camera_moved_at: HashMap::new(),
             shared_blur: HashMap::new(),
             background_last_animate: HashMap::new(),
             background_tick_armed: false,
@@ -134,6 +138,7 @@ impl RenderCache {
         self.shared_blur.remove(output_name);
         self.blur_cache.retain(|(out, _), _| out != output_name);
         self.blur_camera_generation.remove(output_name);
+        self.blur_camera_moved_at.remove(output_name);
         self.background_last_animate.remove(output_name);
         self.cached_error_bar.remove(output_name);
         self.remove_background_chunks(output_name);


### PR DESCRIPTION
animate_blur cost grows with frosted window count (#219): the shared-slice condition from #182 is a z-order test, so on a canvas where windows sit side by side every frosted window except the bottom-most re-renders the whole scene per refresh. Panning makes it worse twice over: camera moves force a shared refresh every frame instead of obeying the throttle, and the window's screen rect is part of the background hash, so stacked windows recompute per pan frame on top.

- fall through to the per-window path only when an element below the window (padded by the blur reach) actually intersects it; side-by-side windows all take the shared slice, overlapping ones keep the current behaviour
- occluded windows drop out of the animated cadence: their refresh is the scene re-render, which is the part that scales. Camera and geometry changes still update them
- camera-forced refreshes obey animate_blur_fps, and occluded recomputes hold while a pan is in flight, catching up 150 ms after settle. Canvas windows move with their backdrop, so the held frost stays correct while panning

Measured on the setup from #219 (3070, 3440x1440@144, animated shader, two frosted terminals, animate_blur_fps 20): idle floor 63-66 W with frost live vs 136 W before, interaction spikes transient, and opening more windows during a storm test moved nothing: fans went down while window count went up.