### PR TITLE
Fix display detection and update Smithay dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smithay"
 version = "0.7.0"
-source = "git+https://github.com/Smithay/smithay.git?rev=5312d5caedd0c2ce563a63719d38ae2183149210#5312d5caedd0c2ce563a63719d38ae2183149210"
+source = "git+https://github.com/Smithay/smithay.git?rev=27af99ef492ab4d7dc5cd2e625374d2beb2772f7#27af99ef492ab4d7dc5cd2e625374d2beb2772f7"
 dependencies = [
  "appendlist",
  "atomic_float",
@@ -2312,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "smithay-drm-extras"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay.git?rev=5312d5caedd0c2ce563a63719d38ae2183149210#5312d5caedd0c2ce563a63719d38ae2183149210"
+source = "git+https://github.com/Smithay/smithay.git?rev=27af99ef492ab4d7dc5cd2e625374d2beb2772f7#27af99ef492ab4d7dc5cd2e625374d2beb2772f7"
 dependencies = [
  "drm",
  "libdisplay-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "A trackpad-first infinite canvas Wayland compositor"
 repository = "https://github.com/malbiruk/driftwm"
 
 [dependencies]
-smithay = { git = "https://github.com/Smithay/smithay.git", rev = "5312d5caedd0c2ce563a63719d38ae2183149210", default-features = false, features = [
+smithay = { git = "https://github.com/Smithay/smithay.git", rev = "27af99ef492ab4d7dc5cd2e625374d2beb2772f7", default-features = false, features = [
     "backend_winit",
     "backend_udev",
     "backend_drm",
@@ -21,7 +21,7 @@ smithay = { git = "https://github.com/Smithay/smithay.git", rev = "5312d5caedd0c
     "wayland_frontend",
     "desktop",
 ] }
-smithay-drm-extras = { git = "https://github.com/Smithay/smithay.git", rev = "5312d5caedd0c2ce563a63719d38ae2183149210" }
+smithay-drm-extras = { git = "https://github.com/Smithay/smithay.git", rev = "27af99ef492ab4d7dc5cd2e625374d2beb2772f7" }
 libdisplay-info = "0.3.0"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 tiff = "0.11"

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -1709,6 +1709,8 @@ fn connector_type_name(connector: &connector::Info) -> &'static str {
         connector::Interface::HDMIA => "HDMI-A",
         connector::Interface::HDMIB => "HDMI-B",
         connector::Interface::EmbeddedDisplayPort => "eDP",
+        connector::Interface::LVDS => "LVDS",
+        connector::Interface::DSI => "DSI",
         connector::Interface::VGA => "VGA",
         _ => "Unknown",
     }


### PR DESCRIPTION
## Description

This PR fixes output detection for LVDS and DSI connectors and updates the
Smithay dependency.

### Changes

- Add missing `LVDS` and `DSI` connector types to DRM connector mapping.
  Without these entries, valid laptop displays could be detected as
  `Unknown-*`.

- Updated Smithay from <5312d5caedd0c2ce563a63719d38ae2183149210> to <27af99ef492ab4d7dc5cd2e625374d2beb2772f7>
  The update includes fixes for screenshot support on older Intel GPUs.

### Testing

Tested on an old laptop with an LVDS display panel and intel i915 GPU (gm45)
<img width="1366" height="767" alt="image_2026-07-25_08-45-09" src="https://github.com/user-attachments/assets/888090a2-d2b6-48c6-8d4f-f5bf6181b4ff" />

```
✿ wlr-randr
LVDS-1 "Seiko Epson Corporation 0x3245 (LVDS-1)"
  Make: Seiko Epson Corporation
  Model: 0x3245
  Physical size: 340x190 mm
  Enabled: yes
  Modes:
    1366x768 px, 60.000000 Hz (preferred, current)
  Position: 0,0
  Transform: normal
  Scale: 1.500000
  Adaptive Sync: disabled
```
