### PR TITLE
Add drawing tablet support (wp-tablet-v2 protocol)

### DIFF
--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -559,13 +559,29 @@ pub fn init_udev(
         .handle()
         .insert_source(libinput_backend, |mut event, _, data| {
             use smithay::backend::input::InputEvent;
+            use smithay::reexports::input::DeviceCapability;
+            use smithay::wayland::tablet_manager::{TabletDescriptor, TabletSeatTrait};
             match &mut event {
                 InputEvent::DeviceAdded { device } => {
                     data.configure_libinput_device(device);
                     data.input_devices.push(device.clone());
+                    if device.has_capability(DeviceCapability::TabletTool) {
+                        let desc = TabletDescriptor::from(&*device);
+                        data.seat
+                            .tablet_seat()
+                            .add_tablet::<DriftWm>(&data.display_handle, &desc);
+                    }
                 }
                 InputEvent::DeviceRemoved { device } => {
                     data.input_devices.retain(|d| d != device);
+                    if device.has_capability(DeviceCapability::TabletTool) {
+                        let desc = TabletDescriptor::from(&*device);
+                        let tablet_seat = data.seat.tablet_seat();
+                        tablet_seat.remove_tablet(&desc);
+                        if tablet_seat.count_tablets() == 0 {
+                            tablet_seat.clear_tools();
+                        }
+                    }
                 }
                 _ => {}
             }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -10,6 +10,7 @@ use smithay::wayland::seat::WaylandFocus;
 use smithay::{
     backend::renderer::ImportDma,
     delegate_cursor_shape, delegate_data_control, delegate_data_device, delegate_dmabuf,
+    delegate_tablet_manager,
     delegate_ext_data_control, delegate_fractional_scale, delegate_idle_inhibit,
     delegate_input_method_manager, delegate_keyboard_shortcuts_inhibit, delegate_output,
     delegate_pointer_constraints, delegate_pointer_gestures, delegate_presentation,
@@ -206,6 +207,8 @@ impl OutputHandler for DriftWm {}
 delegate_output!(DriftWm);
 
 impl TabletSeatHandler for DriftWm {}
+
+delegate_tablet_manager!(DriftWm);
 
 delegate_cursor_shape!(DriftWm);
 

--- a/src/input/gestures/device_config.rs
+++ b/src/input/gestures/device_config.rs
@@ -25,6 +25,8 @@ impl DriftWm {
             self.configure_trackpad(device);
         } else if device.has_capability(smithay::reexports::input::DeviceCapability::Pointer) {
             self.configure_mouse(device);
+        } else if device.has_capability(smithay::reexports::input::DeviceCapability::TabletTool) {
+            self.configure_tablet(device);
         }
     }
 
@@ -81,6 +83,15 @@ impl DriftWm {
                 && let Err(e) = device.config_click_set_method(click)
             {
                 tracing::warn!("Failed to set click_method: {e:?}");
+            }
+        }
+    }
+
+    fn configure_tablet(&self, device: &mut smithay::reexports::input::Device) {
+        tracing::info!("Configuring tablet: {}", device.name());
+        if device.config_left_handed_is_available() {
+            if let Err(e) = device.config_left_handed_set(false) {
+                tracing::warn!("Failed to set tablet left_handed: {e:?}");
             }
         }
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -15,11 +15,16 @@ use smithay::{
     wayland::shell::wlr_layer::Layer as WlrLayer,
 };
 
+use smithay::backend::input::{
+    ProximityState, TabletToolButtonEvent, TabletToolEvent, TabletToolProximityEvent,
+    TabletToolTipEvent, TabletToolTipState,
+};
 use smithay::desktop::Window;
 use smithay::desktop::space::SpaceElement;
 use smithay::reexports::wayland_server::Resource;
 use smithay::wayland::pointer_constraints::{PointerConstraint, with_pointer_constraint};
 use smithay::wayland::seat::WaylandFocus;
+use smithay::wayland::tablet_manager::{TabletDescriptor, TabletSeatTrait};
 
 use smithay::utils::Logical;
 use smithay::wayland::compositor::RegionAttributes;
@@ -302,6 +307,18 @@ impl DriftWm {
                 InputEvent::TouchUp { event } => self.on_touch_up::<I>(event),
                 InputEvent::TouchCancel { event } => self.on_touch_cancel::<I>(event),
                 InputEvent::TouchFrame { event } => self.on_touch_frame::<I>(event),
+                InputEvent::TabletToolAxis { event } => {
+                    self.on_tablet_tool_axis_locked::<I>(event)
+                }
+                InputEvent::TabletToolProximity { event } => {
+                    self.on_tablet_tool_proximity_locked::<I>(event)
+                }
+                InputEvent::TabletToolTip { event } => {
+                    self.on_tablet_tool_tip_locked::<I>(event)
+                }
+                InputEvent::TabletToolButton { event } => {
+                    self.on_tablet_tool_button_locked::<I>(event)
+                }
                 _ => {}
             }
             return;
@@ -344,6 +361,10 @@ impl DriftWm {
             InputEvent::TouchUp { event } => self.on_touch_up::<I>(event),
             InputEvent::TouchCancel { event } => self.on_touch_cancel::<I>(event),
             InputEvent::TouchFrame { event } => self.on_touch_frame::<I>(event),
+            InputEvent::TabletToolAxis { event } => self.on_tablet_tool_axis::<I>(event),
+            InputEvent::TabletToolProximity { event } => self.on_tablet_tool_proximity::<I>(event),
+            InputEvent::TabletToolTip { event } => self.on_tablet_tool_tip::<I>(event),
+            InputEvent::TabletToolButton { event } => self.on_tablet_tool_button::<I>(event),
             _ => {}
         }
     }
@@ -1821,6 +1842,172 @@ impl DriftWm {
             }
         }
         None
+    }
+
+    // -- tablet tool handlers --
+
+    fn tablet_coords<I: InputBackend>(
+        &self,
+        event: &I::TabletToolAxisEvent,
+    ) -> Option<(Point<f64, smithay::utils::Logical>, Point<f64, smithay::utils::Logical>)> {
+        let output = self.active_output()?;
+        let output_geo = self.space.output_geometry(&output)?;
+        let screen_pos = event.position_transformed(output_geo.size);
+        let canvas_pos = screen_to_canvas(ScreenPos(screen_pos), self.camera(), self.zoom()).0;
+        Some((screen_pos, canvas_pos))
+    }
+
+    fn on_tablet_tool_axis_locked<I: InputBackend>(&mut self, event: I::TabletToolAxisEvent) {
+        let Some((screen_pos, _canvas_pos)) = self.tablet_coords::<I>(&event) else {
+            return;
+        };
+        let serial = SERIAL_COUNTER.next_serial();
+        let time = event.time_msec();
+        let pointer = self.seat.get_pointer().unwrap();
+        let focus = self
+            .active_output()
+            .and_then(|o| self.lock_surfaces.get(&o))
+            .map(|ls| {
+                (
+                    FocusTarget(ls.wl_surface().clone()),
+                    Point::<f64, smithay::utils::Logical>::from((0.0, 0.0)),
+                )
+            });
+        pointer.motion(
+            self,
+            focus,
+            &MotionEvent {
+                location: screen_pos,
+                serial,
+                time,
+            },
+        );
+        pointer.frame(self);
+    }
+
+    fn on_tablet_tool_proximity_locked<I: InputBackend>(
+        &mut self,
+        _event: I::TabletToolProximityEvent,
+    ) {
+    }
+
+    fn on_tablet_tool_tip_locked<I: InputBackend>(&mut self, _event: I::TabletToolTipEvent) {}
+
+    fn on_tablet_tool_button_locked<I: InputBackend>(
+        &mut self,
+        _event: I::TabletToolButtonEvent,
+    ) {
+    }
+
+    fn on_tablet_tool_proximity<I: InputBackend>(&mut self, event: I::TabletToolProximityEvent) {
+        let output = match self.active_output() {
+            Some(o) => o,
+            None => return,
+        };
+        let Some(output_geo) = self.space.output_geometry(&output) else {
+            return;
+        };
+        let screen_pos = event.position_transformed(output_geo.size);
+        let canvas_pos = screen_to_canvas(ScreenPos(screen_pos), self.camera(), self.zoom()).0;
+
+        let device = event.device();
+        let tablet_seat = self.seat.tablet_seat();
+        let tool_desc = event.tool();
+        let tablet_desc = TabletDescriptor::from(&device);
+
+        let dh = self.display_handle.clone();
+        let tablet = tablet_seat.add_tablet::<DriftWm>(&dh, &tablet_desc);
+        let tool = tablet_seat.add_tool::<DriftWm>(self, &dh, &tool_desc);
+
+        let serial = SERIAL_COUNTER.next_serial();
+        let time = event.time_msec();
+
+        match event.state() {
+            ProximityState::In => {
+                if let Some((focus, loc)) = self.pointer_focus_under(screen_pos, canvas_pos) {
+                    tool.proximity_in(canvas_pos, (focus.0, loc), &tablet, serial, time);
+                }
+            }
+            ProximityState::Out => {
+                tool.proximity_out(time);
+            }
+        }
+    }
+
+    fn on_tablet_tool_axis<I: InputBackend>(&mut self, event: I::TabletToolAxisEvent) {
+        let Some((screen_pos, canvas_pos)) = self.tablet_coords::<I>(&event) else {
+            return;
+        };
+
+        let device = event.device();
+        let tablet_seat = self.seat.tablet_seat();
+        let tool_desc = event.tool();
+        let tablet_desc = TabletDescriptor::from(&device);
+
+        let Some(tool) = tablet_seat.get_tool(&tool_desc) else {
+            return;
+        };
+        let Some(tablet) = tablet_seat.get_tablet(&tablet_desc) else {
+            return;
+        };
+
+        let serial = SERIAL_COUNTER.next_serial();
+        let time = event.time_msec();
+
+        if event.pressure_has_changed() {
+            tool.pressure(event.pressure());
+        }
+        if event.distance_has_changed() {
+            tool.distance(event.distance());
+        }
+        if event.tilt_has_changed() {
+            tool.tilt(event.tilt());
+        }
+        if event.slider_has_changed() {
+            tool.slider_position(event.slider_position());
+        }
+        if event.rotation_has_changed() {
+            tool.rotation(event.rotation());
+        }
+        if event.wheel_has_changed() {
+            tool.wheel(event.wheel_delta(), event.wheel_delta_discrete());
+        }
+
+        let under = self.pointer_focus_under(screen_pos, canvas_pos);
+        let focus = under.as_ref().map(|(f, loc)| (f.0.clone(), *loc));
+        tool.motion(canvas_pos, focus, &tablet, serial, time);
+
+        // Update cursor position without sending pointer protocol events.
+        if let Some(pointer) = self.seat.get_pointer() {
+            pointer.set_location(canvas_pos);
+        }
+    }
+
+    fn on_tablet_tool_tip<I: InputBackend>(&mut self, event: I::TabletToolTipEvent) {
+        let tool_desc = event.tool();
+        let Some(tool) = self.seat.tablet_seat().get_tool(&tool_desc) else {
+            return;
+        };
+
+        let serial = SERIAL_COUNTER.next_serial();
+        let time = event.time_msec();
+
+        match event.tip_state() {
+            TabletToolTipState::Down => tool.tip_down(serial, time),
+            TabletToolTipState::Up => tool.tip_up(time),
+        }
+    }
+
+    fn on_tablet_tool_button<I: InputBackend>(&mut self, event: I::TabletToolButtonEvent) {
+        let tool_desc = event.tool();
+        let Some(tool) = self.seat.tablet_seat().get_tool(&tool_desc) else {
+            return;
+        };
+
+        let serial = SERIAL_COUNTER.next_serial();
+        let time = event.time_msec();
+
+        tool.button(event.button(), event.button_state(), serial, time);
     }
 }
 

--- a/src/state/init.rs
+++ b/src/state/init.rs
@@ -39,6 +39,7 @@ use smithay::{
         },
         shm::ShmState,
         single_pixel_buffer::SinglePixelBufferState,
+        tablet_manager::TabletManagerState,
         text_input::TextInputManagerState,
         viewporter::ViewporterState,
         virtual_keyboard::VirtualKeyboardManagerState,
@@ -111,6 +112,7 @@ impl DriftWm {
         let mut seat_state = SeatState::new();
         let data_device_state = DataDeviceState::new::<Self>(&dh);
 
+        let tablet_manager_state = TabletManagerState::new::<Self>(&dh);
         let cursor_shape_state = CursorShapeManagerState::new::<Self>(&dh);
         let viewporter_state = ViewporterState::new::<Self>(&dh);
         let fractional_scale_state = FractionalScaleManagerState::new::<Self>(&dh);
@@ -302,6 +304,7 @@ impl DriftWm {
             dmabuf_global: None,
             render_device: None,
             render_dmabuf_formats: None,
+            tablet_manager_state,
             cursor_shape_state,
             viewporter_state,
             fractional_scale_state,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -73,6 +73,7 @@ use smithay::wayland::selection::ext_data_control::DataControlState as ExtDataCo
 use smithay::wayland::selection::primary_selection::PrimarySelectionState;
 use smithay::wayland::selection::wlr_data_control::DataControlState;
 use smithay::wayland::session_lock::{LockSurface, SessionLockManagerState, SessionLocker};
+use smithay::wayland::tablet_manager::TabletManagerState;
 use smithay::wayland::shell::wlr_layer::WlrLayerShellState;
 use smithay::wayland::shell::xdg::decoration::XdgDecorationState;
 use smithay::wayland::viewporter::ViewporterState;
@@ -552,6 +553,8 @@ pub struct DriftWm {
     /// compositor has no direct DRM device). Used by ext-image-copy-capture.
     pub render_device: Option<u64>,
     pub render_dmabuf_formats: Option<smithay::backend::allocator::format::FormatSet>,
+    #[allow(dead_code)]
+    pub tablet_manager_state: TabletManagerState,
     #[allow(dead_code)]
     pub cursor_shape_state: CursorShapeManagerState,
     #[allow(dead_code)]


### PR DESCRIPTION
It's my first time making fork and make a pull request, i'm sorry for anything if goes wrong. Anyway this PR add drawing tab support to driftwm, also it's vibecoded because i still learn code and still don't know many syntax. I create this because i need to draw in krita using my drawing tab and also to fulfill #118 