### PR TITLE
Replace .unwrap() calls on seat accessors with graceful error handling

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1186,24 +1186,22 @@ impl SessionLockHandler for DriftWm {
             self.loop_handle.remove(pending.timer_token);
         }
         let serial = smithay::utils::SERIAL_COUNTER.next_serial();
-        let pointer = self.seat.get_pointer().unwrap();
-        pointer.unset_grab(self, serial, 0);
+        if let Some(pointer) = self.seat.get_pointer() {
+            pointer.unset_grab(self, serial, 0);
 
-        // Deactivate any pointer constraint held on the current focus surface.
-        // Without this, a Wine game (or any client with a Locked constraint)
-        // keeps the cursor pinned through unlock — the lock screen can't move.
-        if let Some(focus) = pointer.current_focus() {
-            smithay::wayland::pointer_constraints::with_pointer_constraint(
-                &focus.0,
-                &pointer,
-                |c| {
-                    if let Some(c) = c
-                        && c.is_active()
-                    {
-                        c.deactivate();
-                    }
-                },
-            );
+            if let Some(focus) = pointer.current_focus() {
+                smithay::wayland::pointer_constraints::with_pointer_constraint(
+                    &focus.0,
+                    &pointer,
+                    |c| {
+                        if let Some(c) = c
+                            && c.is_active()
+                        {
+                            c.deactivate();
+                        }
+                    },
+                );
+            }
         }
 
         self.cursor.exec_cursor_show_at = None;

--- a/src/state/reload.rs
+++ b/src/state/reload.rs
@@ -52,22 +52,26 @@ impl DriftWm {
                 model: &kb.model,
                 ..Default::default()
             };
-            let keyboard = self.seat.get_keyboard().unwrap();
-            let num_lock = keyboard.modifier_state().num_lock;
-            if let Err(err) = keyboard.set_xkb_config(self, xkb) {
-                tracing::warn!("Config reload: error updating keyboard layout: {err:?}");
-                self.set_error(
-                    ErrorSource::Keyboard,
-                    "keyboard: invalid layout config — keeping previous".to_string(),
-                );
-                new_config.keyboard_layout = self.config.keyboard_layout.clone();
-            } else {
-                tracing::info!("Config reload: keyboard layout updated");
-                let mut mods = keyboard.modifier_state();
-                if mods.num_lock != num_lock {
-                    mods.num_lock = num_lock;
-                    keyboard.set_modifier_state(mods);
+            if let Some(keyboard) = self.seat.get_keyboard() {
+                let num_lock = keyboard.modifier_state().num_lock;
+                if let Err(err) = keyboard.set_xkb_config(self, xkb) {
+                    tracing::warn!("Config reload: error updating keyboard layout: {err:?}");
+                    self.set_error(
+                        ErrorSource::Keyboard,
+                        "keyboard: invalid layout config — keeping previous".to_string(),
+                    );
+                    new_config.keyboard_layout = self.config.keyboard_layout.clone();
+                } else {
+                    tracing::info!("Config reload: keyboard layout updated");
+                    let mut mods = keyboard.modifier_state();
+                    if mods.num_lock != num_lock {
+                        mods.num_lock = num_lock;
+                        keyboard.set_modifier_state(mods);
+                    }
                 }
+            } else {
+                tracing::warn!("Config reload: no keyboard seat, skipping layout update");
+                new_config.keyboard_layout = self.config.keyboard_layout.clone();
             }
         }
         if new_config.autostart != self.config.autostart {
@@ -77,8 +81,11 @@ impl DriftWm {
         if new_config.repeat_rate != self.config.repeat_rate
             || new_config.repeat_delay != self.config.repeat_delay
         {
-            let keyboard = self.seat.get_keyboard().unwrap();
-            keyboard.change_repeat_info(new_config.repeat_rate, new_config.repeat_delay);
+            if let Some(keyboard) = self.seat.get_keyboard() {
+                keyboard.change_repeat_info(new_config.repeat_rate, new_config.repeat_delay);
+            } else {
+                tracing::warn!("Config reload: no keyboard seat, skipping repeat rate update");
+            }
         }
 
         if new_config.drift != self.config.drift {


### PR DESCRIPTION
Two defensive fixes for config hot-reload and session-lock paths:

1. `state/reload.rs` - `reload_config_from_contents` called
   `seat.get_keyboard().unwrap()` twice when the keyboard layout or
   repeat rate changed. If the keyboard seat is absent during reload
   (possible during early init), this panics the compositor.
   Changed both to `if let Some(keyboard)` with a warning log and
   graceful fallback (keep the existing config).

2. `handlers/mod.rs` - `SessionLockHandler::lock()` called
   `seat.get_pointer().unwrap()`. Same panic risk if the pointer
   seat isn't available. Changed to `if let Some(pointer)`.

Both paths are guarded by equivalent checks elsewhere in the codebase;
this brings the reload and lock paths in line with the rest.