### PR TITLE
fix: guard against layer-surface buffer-before-ack protocol error

### DIFF
--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -7,7 +7,6 @@ use crate::state::{ClientState, DriftWm, FocusTarget, PendingRecenter, StageWind
 use driftwm::window_ext::WindowExt;
 use smithay::desktop::layer_map_for_output;
 use smithay::utils::{Logical, Point, Rectangle};
-use smithay::wayland::shell::wlr_layer::{Anchor, LayerSurfaceCachedState, LayerSurfaceData};
 use smithay::{
     delegate_compositor, delegate_shm,
     reexports::{
@@ -23,6 +22,8 @@ use smithay::{
         },
         dmabuf::get_dmabuf,
         seat::WaylandFocus,
+        session_lock::LockSurfaceData,
+        shell::wlr_layer::{Anchor, LayerSurfaceCachedState, LayerSurfaceData},
         shell::xdg::XdgToplevelSurfaceData,
         shm::{ShmHandler, ShmState},
     },
@@ -85,29 +86,31 @@ impl CompositorHandler for DriftWm {
             });
         });
 
-        // Guard against layer-surface buffer-before-ack races (noctalia/
-        // quickshell).  If the pending buffer is a NewBuffer but the layer
-        // surface hasn't acked its initial configure, clear the buffer so
-        // smithay's protocol validation does not post a protocol error
-        // that kills the client.  The client will ack the configure and
-        // retry the buffer on its next commit.
+        // Guard against buffer-before-ack races on layer surfaces (noctalia/
+        // quickshell bar, clipboard) and session lock surfaces (noctalia lock
+        // screen).  If the pending buffer is a NewBuffer but the surface hasn't
+        // acked its initial configure, clear the buffer so smithay's protocol
+        // validation does not post a protocol error that kills the client.
+        // The client will ack the configure and retry the buffer.
         add_pre_commit_hook::<DriftWm, _>(surface, |_state, _dh, surface| {
             with_states(surface, |states| {
-                let Some(role) = states.data_map.get::<LayerSurfaceData>() else {
-                    return;
-                };
-                if role
-                    .lock()
-                    .ok()
-                    .is_some_and(|guard| guard.last_acked.is_some())
-                {
-                    return;
-                }
-                let mut attrs = states.cached_state.get::<SurfaceAttributes>();
-                let has_new_buffer =
-                    matches!(attrs.pending().buffer, Some(BufferAssignment::NewBuffer(_)));
-                if has_new_buffer {
-                    attrs.pending().buffer = Some(BufferAssignment::Removed);
+                let layer_needs_ack = states
+                    .data_map
+                    .get::<LayerSurfaceData>()
+                    .and_then(|role| role.lock().ok())
+                    .is_some_and(|guard| guard.last_acked.is_none());
+                let lock_needs_ack = states
+                    .data_map
+                    .get::<LockSurfaceData>()
+                    .and_then(|role| role.lock().ok())
+                    .is_some_and(|guard| guard.last_acked.is_none());
+                if layer_needs_ack || lock_needs_ack {
+                    let mut attrs = states.cached_state.get::<SurfaceAttributes>();
+                    let has_new_buffer =
+                        matches!(attrs.pending().buffer, Some(BufferAssignment::NewBuffer(_)));
+                    if has_new_buffer {
+                        attrs.pending().buffer = Some(BufferAssignment::Removed);
+                    }
                 }
             });
         });

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -96,14 +96,16 @@ impl CompositorHandler for DriftWm {
                 let Some(role) = states.data_map.get::<LayerSurfaceData>() else {
                     return;
                 };
-                if role.lock().ok().is_some_and(|guard| guard.last_acked.is_some()) {
+                if role
+                    .lock()
+                    .ok()
+                    .is_some_and(|guard| guard.last_acked.is_some())
+                {
                     return;
                 }
                 let mut attrs = states.cached_state.get::<SurfaceAttributes>();
-                let has_new_buffer = matches!(
-                    attrs.pending().buffer,
-                    Some(BufferAssignment::NewBuffer(_))
-                );
+                let has_new_buffer =
+                    matches!(attrs.pending().buffer, Some(BufferAssignment::NewBuffer(_)));
                 if has_new_buffer {
                     attrs.pending().buffer = Some(BufferAssignment::Removed);
                 }

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use crate::decorations::DecorationKey;
 use crate::grabs::{ResizeState, has_left, has_top};
 use crate::handlers::layer_shell::LayerDestroyedMarker;
-use crate::state::{ClientState, DriftWm, FocusTarget, PendingRecenter, StageWindow};
+use crate::state::{ClientState, DriftWm, FocusTarget, PendingRecenter, SessionLock, StageWindow};
 use driftwm::window_ext::WindowExt;
 use smithay::desktop::layer_map_for_output;
 use smithay::utils::{Logical, Point, Rectangle};
@@ -109,7 +109,7 @@ impl CompositorHandler for DriftWm {
                     let has_new_buffer =
                         matches!(attrs.pending().buffer, Some(BufferAssignment::NewBuffer(_)));
                     if has_new_buffer {
-                        attrs.pending().buffer = Some(BufferAssignment::Removed);
+                        attrs.pending().buffer = None;
                     }
                 }
             });
@@ -250,28 +250,44 @@ impl CompositorHandler for DriftWm {
             });
         }
 
-        // Confirm session lock on the lock surface's first buffer commit.
-        if let crate::state::SessionLock::Pending(_) = &self.session_lock {
-            let is_lock_surface = self
+        // Accumulate lock surface commits and confirm only when all are ready.
+        if let crate::state::SessionLock::Pending {
+            ref mut ready_outputs,
+            ..
+        } = self.session_lock
+        {
+            let Some(output) = self
                 .lock_surfaces
-                .values()
-                .any(|ls| ls.wl_surface() == surface);
-            if is_lock_surface {
-                // locker.lock() consumes — take it out of the enum. The lock
-                // object outlives it in `Locked`, where a later lock request
-                // reads its liveness.
+                .iter()
+                .find(|(_, ls)| ls.wl_surface() == surface)
+                .map(|(o, _)| o.clone())
+            else {
+                return;
+            };
+            ready_outputs.insert(output);
+
+            let all_ready = self.lock_surfaces.keys().all(|o| ready_outputs.contains(o));
+            if all_ready {
                 let old =
-                    std::mem::replace(&mut self.session_lock, crate::state::SessionLock::Unlocked);
-                if let crate::state::SessionLock::Pending(locker) = old {
+                    std::mem::replace(&mut self.session_lock, SessionLock::Unlocked);
+                if let SessionLock::Pending {
+                    locker,
+                    deadline_token,
+                    ..
+                } = old
+                {
+                    if let Some(token) = deadline_token {
+                        self.loop_handle.remove(token);
+                    }
                     let lock = locker.ext_session_lock().clone();
                     locker.lock();
-                    self.session_lock = crate::state::SessionLock::Locked(lock);
+                    self.session_lock = SessionLock::Locked(lock);
                     tracing::info!("Session lock confirmed");
                     let serial = smithay::utils::SERIAL_COUNTER.next_serial();
                     self.set_keyboard_focus(Some(FocusTarget(surface.clone())), serial);
                 }
-                return;
             }
+            return;
         }
 
         if !is_sync_subsurface(surface) {

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -268,8 +268,7 @@ impl CompositorHandler for DriftWm {
 
             let all_ready = self.lock_surfaces.keys().all(|o| ready_outputs.contains(o));
             if all_ready {
-                let old =
-                    std::mem::replace(&mut self.session_lock, SessionLock::Unlocked);
+                let old = std::mem::replace(&mut self.session_lock, SessionLock::Unlocked);
                 if let SessionLock::Pending {
                     locker,
                     deadline_token,

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -85,6 +85,31 @@ impl CompositorHandler for DriftWm {
             });
         });
 
+        // Guard against layer-surface buffer-before-ack races (noctalia/
+        // quickshell).  If the pending buffer is a NewBuffer but the layer
+        // surface hasn't acked its initial configure, clear the buffer so
+        // smithay's protocol validation does not post a protocol error
+        // that kills the client.  The client will ack the configure and
+        // retry the buffer on its next commit.
+        add_pre_commit_hook::<DriftWm, _>(surface, |_state, _dh, surface| {
+            with_states(surface, |states| {
+                let Some(role) = states.data_map.get::<LayerSurfaceData>() else {
+                    return;
+                };
+                if role.lock().ok().is_some_and(|guard| guard.last_acked.is_some()) {
+                    return;
+                }
+                let mut attrs = states.cached_state.get::<SurfaceAttributes>();
+                let has_new_buffer = matches!(
+                    attrs.pending().buffer,
+                    Some(BufferAssignment::NewBuffer(_))
+                );
+                if has_new_buffer {
+                    attrs.pending().buffer = Some(BufferAssignment::Removed);
+                }
+            });
+        });
+
         // Snapshot a mapped toplevel's markless-conversion inputs the instant it
         // unmaps. Registered before smithay's xdg role-reset hook (which fires on
         // the null-buffer commit and wipes app_id / title / geometry), so a

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1118,9 +1118,11 @@ driftwm::delegate_output_management!(DriftWm);
 
 use crate::state::SessionLock;
 use smithay::delegate_session_lock;
+use smithay::reexports::calloop::timer::{TimeoutAction, Timer};
 use smithay::wayland::session_lock::{
     LockSurface, SessionLockHandler, SessionLockManagerState, SessionLocker,
 };
+use std::collections::HashSet;
 
 impl SessionLockHandler for DriftWm {
     fn lock_state(&mut self) -> &mut SessionLockManagerState {
@@ -1157,13 +1159,39 @@ impl SessionLockHandler for DriftWm {
             // the new lock surface the keyboard on its first commit.
             Some(_) => {
                 tracing::info!("Replacing a session lock whose client died");
-                self.session_lock = SessionLock::Pending(confirmation);
+                self.session_lock = SessionLock::Pending {
+                    locker: confirmation,
+                    ready_outputs: HashSet::new(),
+                    deadline_token: None,
+                };
                 return;
             }
             None => {}
         }
         tracing::info!("Session lock requested");
-        self.session_lock = SessionLock::Pending(confirmation);
+
+        // 1-second deadline: force-lock even if not all surfaces mapped yet.
+        let deadline_token = {
+            let timer = Timer::from_duration(std::time::Duration::from_millis(1000));
+            self.loop_handle
+                .insert_source(timer, |_, _, data: &mut DriftWm| {
+                    let old = std::mem::replace(&mut data.session_lock, SessionLock::Unlocked);
+                    if let SessionLock::Pending { locker, .. } = old {
+                        let lock = locker.ext_session_lock().clone();
+                        locker.lock();
+                        data.session_lock = SessionLock::Locked(lock);
+                        tracing::info!("Session lock confirmed (deadline)");
+                    }
+                    TimeoutAction::Drop
+                })
+                .ok()
+        };
+
+        self.session_lock = SessionLock::Pending {
+            locker: confirmation,
+            ready_outputs: HashSet::new(),
+            deadline_token,
+        };
 
         // Kill all transient input/animation state so nothing fires during lock
         self.gesture_state = None;
@@ -1298,6 +1326,14 @@ impl SessionLockHandler for DriftWm {
             return;
         }
         tracing::info!("Session unlocked");
+        // Remove deadline timer if still active.
+        if let SessionLock::Pending {
+            deadline_token: Some(token),
+            ..
+        } = &self.session_lock
+        {
+            self.loop_handle.remove(*token);
+        }
         // Undo the canvas→screen conversion `lock` established, before anything
         // hit-tests with the stored location again.
         let pointer = self.seat.get_pointer().unwrap();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -201,8 +201,14 @@ pub struct PendingPick {
 /// Session lock state machine: Unlocked → Pending → Locked → Unlocked.
 pub enum SessionLock {
     Unlocked,
-    /// Lock requested; screen goes black until lock surface commits.
-    Pending(SessionLocker),
+    /// Lock requested; waiting for all lock surfaces to commit a buffer.
+    Pending {
+        locker: SessionLocker,
+        /// Outputs whose lock surface has committed a buffer.
+        ready_outputs: HashSet<Output>,
+        /// 1-second deadline timer to force-lock if a client is slow.
+        deadline_token: Option<RegistrationToken>,
+    },
     /// Lock confirmed; rendering only the lock surface. Carries the client's
     /// lock object purely so a later lock request can tell a live locker (which
     /// it must not displace) from one whose client died (which it may).
@@ -223,7 +229,7 @@ impl SessionLock {
     pub fn incumbent(&self) -> Option<&ExtSessionLockV1> {
         match self {
             SessionLock::Unlocked => None,
-            SessionLock::Pending(locker) => Some(locker.ext_session_lock()),
+            SessionLock::Pending { locker, .. } => Some(locker.ext_session_lock()),
             SessionLock::Locked(lock) => Some(lock),
         }
     }


### PR DESCRIPTION
## Problem
Noctalia (via quickshell) can commit a buffer to a `zwlr_layer_surface_v1` before acknowledging the initial configure event. Smithay's layer-shell commit handler treats this as `InvalidSurfaceState` protocol error and kills the client (noctalia). This manifests as random crashes — especially when panels (clipboard history, etc.) are opened and closed rapidly.
## Root cause
Race in quickshell's layer-surface lifecycle — it attaches a buffer in the same dispatch cycle as the initial commit, before the configure event from the compositor has been processed and acknowledged.
## Fix
A pre-commit hook (registered before smithay's validation hook in `new_surface`) that reads `last_acked` from the layer-surface role (`LayerSurfaceData`). If `last_acked` is None (configure not yet acknowledged) and the pending state contains a `NewBuffer`, the buffer is removed (set to `Removed`). Smithay's commit handler then sees no buffer, skips the protocol error, and the client safely acks the configure and retries the buffer on the next commit.
## Notes
- Only fires for surfaces with `LayerSurfaceData` — regular xdg-toplevel windows are unaffected.
- Reads `last_acked` from the role data (`LayerSurfaceAttributes` via `LayerSurfaceData`), not from `LayerSurfaceCachedState.pending()` — the role's `last_acked` is updated immediately by `ack_configure`, while the cached state is only synced on the next commit.
- Other compositors (wlroots, Hyprland) handle this case leniently — they ignore the premature buffer rather than killing the client. This patch adopts the same behavior.