### PR TITLE
fix: render normal windows during Pending lock state, switch to lock frame only when fully Locked

### DIFF
--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -240,10 +240,11 @@ impl CompositorHandler for DriftWm {
 
             let all_ready = self.lock_surfaces.keys().all(|o| ready_outputs.contains(o));
             if all_ready {
+                // Cancel the deadline timer BEFORE we move out of Pending.
+                self.cancel_pending_deadline();
                 let old =
                     std::mem::replace(&mut self.session_lock, crate::state::SessionLock::Unlocked);
                 if let crate::state::SessionLock::Pending { locker, .. } = old {
-                    self.cancel_pending_deadline();
                     self.enter_locked(locker);
                     let serial = smithay::utils::SERIAL_COUNTER.next_serial();
                     self.set_keyboard_focus(Some(FocusTarget(surface.clone())), serial);

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -220,25 +220,36 @@ impl CompositorHandler for DriftWm {
             });
         }
 
-        // Confirm session lock on the lock surface's first buffer commit.
-        if let crate::state::SessionLock::Pending(_) = &self.session_lock {
-            let is_lock_surface = self
+        // Accumulate lock-surface commits during `Pending` and only enter
+        // `Locked` once every output's lock surface has committed its first
+        // buffer. This avoids a blank flash when the desktop is still showing.
+        if let crate::state::SessionLock::Pending {
+            ref mut ready_outputs,
+            ..
+        } = self.session_lock
+        {
+            let Some(output) = self
                 .lock_surfaces
-                .values()
-                .any(|ls| ls.wl_surface() == surface);
-            if is_lock_surface {
-                // The locker is consumed by whatever eventually sends `locked` —
-                // take it out of the enum. The lock object outlives it in
-                // `Locked`, where a later lock request reads its liveness.
+                .iter()
+                .find(|(_, ls)| ls.wl_surface() == surface)
+                .map(|(o, _)| o.clone())
+            else {
+                return;
+            };
+            ready_outputs.insert(output);
+
+            let all_ready = self.lock_surfaces.keys().all(|o| ready_outputs.contains(o));
+            if all_ready {
                 let old =
                     std::mem::replace(&mut self.session_lock, crate::state::SessionLock::Unlocked);
-                if let crate::state::SessionLock::Pending(locker) = old {
+                if let crate::state::SessionLock::Pending { locker, .. } = old {
+                    self.cancel_pending_deadline();
                     self.enter_locked(locker);
                     let serial = smithay::utils::SERIAL_COUNTER.next_serial();
                     self.set_keyboard_focus(Some(FocusTarget(surface.clone())), serial);
                 }
-                return;
             }
+            return;
         }
 
         if !is_sync_subsurface(surface) {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1131,6 +1131,7 @@ use smithay::delegate_session_lock;
 use smithay::wayland::session_lock::{
     LockSurface, SessionLockHandler, SessionLockManagerState, SessionLocker,
 };
+use std::collections::HashSet;
 
 impl SessionLockHandler for DriftWm {
     fn lock_state(&mut self) -> &mut SessionLockManagerState {
@@ -1167,20 +1168,25 @@ impl SessionLockHandler for DriftWm {
             // the new lock surface the keyboard on its first commit.
             Some(_) => {
                 tracing::info!("Replacing a session lock whose client died");
-                // Assigning over `Locked` drops the dead client's unconsumed
-                // locker but not its repeating confirmation timer, which would
-                // go on waking the loop for as long as the newcomer sits in
-                // `Pending`. Harmless if it fired — the timer's identity check
-                // sees a lock it no longer matches — but there is no reason to
-                // keep it armed.
+                self.cancel_pending_deadline();
                 self.cancel_lock_confirm_timer();
-                self.session_lock = SessionLock::Pending(confirmation);
+                let token = self.arm_pending_deadline();
+                self.session_lock = SessionLock::Pending {
+                    locker: confirmation,
+                    ready_outputs: HashSet::new(),
+                    deadline_token: token,
+                };
                 return;
             }
             None => {}
         }
         tracing::info!("Session lock requested");
-        self.session_lock = SessionLock::Pending(confirmation);
+        let token = self.arm_pending_deadline();
+        self.session_lock = SessionLock::Pending {
+            locker: confirmation,
+            ready_outputs: HashSet::new(),
+            deadline_token: token,
+        };
 
         // Kill all transient input/animation state so nothing fires during lock
         self.gesture_state = None;
@@ -1315,6 +1321,9 @@ impl SessionLockHandler for DriftWm {
             return;
         }
         tracing::info!("Session unlocked");
+        // Cancel both timers: the Pending deadline and the Locked confirm backstop.
+        self.cancel_pending_deadline();
+        self.cancel_lock_confirm_timer();
         // Undo the canvas→screen conversion `lock` established, before anything
         // hit-tests with the stored location again.
         let pointer = self.seat.get_pointer().unwrap();
@@ -1325,7 +1334,6 @@ impl SessionLockHandler for DriftWm {
         )
         .0;
         pointer.set_location(canvas_pos);
-        self.cancel_lock_confirm_timer();
         self.session_lock = SessionLock::Unlocked;
         self.lock_surfaces.clear();
         // A finger still down at unlock would otherwise leave its slot

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -200,10 +200,21 @@ pub struct PendingPick {
 }
 
 /// Session lock state machine: Unlocked → Pending → Locked → Unlocked.
+///
+/// `Pending` renders the normal desktop (no flash) while waiting for all lock
+/// surfaces to commit their first buffer, with a 1-second deadline after which
+/// we force-enter `Locked` regardless. `Locked` renders lock frames and defers
+/// the `locked` protocol event until every output has presented one.
 pub enum SessionLock {
     Unlocked,
-    /// Lock requested; screen goes black until lock surface commits.
-    Pending(SessionLocker),
+    /// Lock requested; desktop still visible until lock surfaces commit.
+    Pending {
+        locker: SessionLocker,
+        /// Outputs whose lock surface has committed its first buffer.
+        ready_outputs: HashSet<Output>,
+        /// 1-second deadline: force `Locked` even if not all surfaces mapped.
+        deadline_token: Option<RegistrationToken>,
+    },
     /// Rendering only the lock surface. Carries the client's lock object partly
     /// so a later lock request can tell a live locker (which it must not
     /// displace) from one whose client died (which it may).
@@ -232,7 +243,7 @@ impl SessionLock {
 
     /// Whether the compositor is currently painting a lock frame rather than the
     /// desktop. Deliberately distinct from [`Self::is_locked`], which gates
-    /// input: the two answer different questions and coincide only today.
+    /// input: the two answer different questions.
     ///
     /// The renderer and the lock-frame bookkeeping must both read *this* — a
     /// disagreement about whether a given frame was a lock frame would make the
@@ -242,7 +253,7 @@ impl SessionLock {
     /// space the pointer is in, which is settled when `Pending` is entered, not
     /// what the frame paints.
     pub fn renders_lock_frame(&self) -> bool {
-        !matches!(self, SessionLock::Unlocked)
+        matches!(self, SessionLock::Locked { .. })
     }
 
     /// The lock object of the client that owns the session, pending or
@@ -251,7 +262,7 @@ impl SessionLock {
     pub fn incumbent(&self) -> Option<&ExtSessionLockV1> {
         match self {
             SessionLock::Unlocked => None,
-            SessionLock::Pending(locker) => Some(locker.ext_session_lock()),
+            SessionLock::Pending { locker, .. } => Some(locker.ext_session_lock()),
             SessionLock::Locked { lock, .. } => Some(lock),
         }
     }

--- a/src/state/session_lock.rs
+++ b/src/state/session_lock.rs
@@ -14,7 +14,10 @@ use driftwm::protocols::output_power::OutputPowerHandler;
 use smithay::{
     output::Output,
     reexports::{
-        calloop::timer::{TimeoutAction, Timer},
+        calloop::{
+            RegistrationToken,
+            timer::{TimeoutAction, Timer},
+        },
         drm::control::crtc,
         wayland_protocols::ext::session_lock::v1::server::ext_session_lock_v1::ExtSessionLockV1,
     },
@@ -169,6 +172,41 @@ impl DriftWm {
     pub fn cancel_lock_confirm_timer(&mut self) {
         if let Some(token) = self.lock_confirm_timer.take() {
             self.loop_handle.remove(token);
+        }
+    }
+
+    /// Cancel the pending deadline timer, if any.
+    pub fn cancel_pending_deadline(&mut self) {
+        if let SessionLock::Pending { deadline_token, .. } = &mut self.session_lock
+            && let Some(token) = deadline_token.take()
+        {
+            self.loop_handle.remove(token);
+        }
+    }
+
+    /// Arm a one-second deadline that forces `Pending → Locked` even if not all
+    /// lock surfaces have committed. Returns `None` when the timer cannot be
+    /// inserted (the compositor will keep showing the desktop until the surfaces
+    /// commit, which may never come without the backstop).
+    pub fn arm_pending_deadline(&mut self) -> Option<RegistrationToken> {
+        match self.loop_handle.insert_source(
+            Timer::from_duration(Duration::from_millis(1000)),
+            |_, _, data: &mut DriftWm| {
+                let old = std::mem::replace(&mut data.session_lock, SessionLock::Unlocked);
+                if let SessionLock::Pending { locker, .. } = old {
+                    data.enter_locked(locker);
+                }
+                TimeoutAction::Drop
+            },
+        ) {
+            Ok(token) => {
+                tracing::trace!("Pending lock deadline armed (1s)");
+                Some(token)
+            }
+            Err(e) => {
+                tracing::error!("Failed to arm pending lock deadline: {e:?}");
+                None
+            }
         }
     }
 

--- a/src/state/session_lock.rs
+++ b/src/state/session_lock.rs
@@ -192,6 +192,9 @@ impl DriftWm {
         match self.loop_handle.insert_source(
             Timer::from_duration(Duration::from_millis(1000)),
             |_, _, data: &mut DriftWm| {
+                if !matches!(data.session_lock, SessionLock::Pending { .. }) {
+                    return TimeoutAction::Drop;
+                }
                 let old = std::mem::replace(&mut data.session_lock, SessionLock::Unlocked);
                 if let SessionLock::Pending { locker, .. } = old {
                     data.enter_locked(locker);


### PR DESCRIPTION
# Prevents the screen flickering after locking.
## Before
After locking, the screen goes black for a very small (but noticable) period of time, because of the lock screen being prepared and not rendered yet (`is_locked()` is actually `!Unlocked` rather than just `Locked`). Nothing is being rendered -> screen is black.
## After
Renders the lock screen only when actually `Locked`
## Alternative
Change `is_locked()` behavior to return `true` when the session lock state is `Locked`, instead of it returning `true` at any state but `Unlocked`. But it seems that `is_locked()` is being used in many placed of the codebase, especially in input handling, so I decided to play it safe and this PR only hard-codes a specific behavior for lock screen rendering. Let me know if you prefer that `is_locked()` be changed instead