### PR TITLE
fix: Re-seat pointer focus when a layer under the cursor is destroyed

### DIFF
--- a/src/handlers/layer_shell.rs
+++ b/src/handlers/layer_shell.rs
@@ -202,14 +202,10 @@ impl WlrLayerShellHandler for DriftWm {
         // smithay's pointer focus are only refreshed by real pointer motion, so
         // without this a layer destroyed under a stationary cursor would route
         // the next press/scroll to the canvas instead of the layer surface still
-        // beneath it. `layer_surface_under` skips the role-destroyed surface via
-        // the marker above, so the recompute lands on whatever is genuinely under
-        // the cursor. No-op while locked; `unlock` re-seats pointer focus anyway.
-        if self.session_lock.is_locked() {
-            self.pointer_over_layer = false;
-        } else {
-            self.refresh_pointer_focus();
-        }
+        // beneath it. The layer was unmapped above, so the recompute lands on
+        // whatever is genuinely under the cursor. No-op while locked — `unlock`
+        // re-seats pointer focus anyway.
+        self.refresh_pointer_focus();
 
         // Drop on-demand tracking if it pointed at this surface, then recompute
         // focus — it falls back to the next layer or the focused window.

--- a/src/handlers/layer_shell.rs
+++ b/src/handlers/layer_shell.rs
@@ -183,14 +183,9 @@ impl WlrLayerShellHandler for DriftWm {
         self.canvas_layers
             .retain(|cl| cl.surface.wl_surface() != surface.wl_surface());
 
-        // Reset pointer_over_layer — the surface may have been under the pointer.
-        // Next motion event will re-evaluate, but this prevents stale state in between.
-        self.pointer_over_layer = false;
-
-        // Mark this surface so our early pre-commit hook can neutralise the
-        // orphaned commits before smithay's layer-shell validation runs. We
-        // can't fix the cached state here directly because smithay resets it to
-        // defaults AFTER this callback.
+        // Mark this surface so our early pre-commit hook can set full anchors
+        // before smithay's layer-shell validation runs. We can't set anchors here
+        // directly because smithay resets cached state to defaults AFTER this callback.
         with_states(surface.wl_surface(), |states| {
             states
                 .data_map
@@ -202,6 +197,19 @@ impl WlrLayerShellHandler for DriftWm {
                 .0
                 .store(true, Ordering::Relaxed);
         });
+
+        // The surface may have been under the pointer. `pointer_over_layer` and
+        // smithay's pointer focus are only refreshed by real pointer motion, so
+        // without this a layer destroyed under a stationary cursor would route
+        // the next press/scroll to the canvas instead of the layer surface still
+        // beneath it. `layer_surface_under` skips the role-destroyed surface via
+        // the marker above, so the recompute lands on whatever is genuinely under
+        // the cursor. No-op while locked; `unlock` re-seats pointer focus anyway.
+        if self.session_lock.is_locked() {
+            self.pointer_over_layer = false;
+        } else {
+            self.refresh_pointer_focus();
+        }
 
         // Drop on-demand tracking if it pointed at this surface, then recompute
         // focus — it falls back to the next layer or the focused window.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -22,13 +22,11 @@ use smithay::wayland::pointer_constraints::{PointerConstraint, with_pointer_cons
 use smithay::wayland::seat::WaylandFocus;
 
 use smithay::utils::Logical;
-use smithay::wayland::compositor::{RegionAttributes, with_states};
+use smithay::wayland::compositor::RegionAttributes;
 
 use std::rc::Rc;
-use std::sync::atomic::Ordering;
 
 use crate::decorations::{DecorationHit, DecorationKey};
-use crate::handlers::layer_shell::LayerDestroyedMarker;
 use crate::state::{DriftWm, FocusTarget, PickTarget, StageWindow, SuspendedWindow};
 use driftwm::canvas::{
     CanvasPos, ScreenPos, clamp_to_output, screen_space_focus_loc, screen_to_canvas,
@@ -2083,21 +2081,6 @@ impl DriftWm {
             // even though its bbox contains it, and the surface beneath must
             // still receive the input.
             for (surface, geo) in self.layers_on_sorted(&output, layer) {
-                // Skip a surface whose layer-shell role was destroyed but which
-                // is still listed in smithay's layer map until cleanup: its
-                // buffer geometry is stale, and hit-testing it would pin the
-                // pointer to a dead surface. `layer_destroyed` sets this marker
-                // before it recomputes pointer focus, so the recompute lands on
-                // whatever genuinely sits beneath the cursor.
-                let role_destroyed = with_states(surface.wl_surface(), |states| {
-                    states
-                        .data_map
-                        .get::<LayerDestroyedMarker>()
-                        .is_some_and(|m| m.0.load(Ordering::Relaxed))
-                });
-                if role_destroyed {
-                    continue;
-                }
                 let surface_local = screen_pos - geo.loc.to_f64();
                 if let Some((wl_surface, sub_loc)) =
                     surface.surface_under(surface_local, WindowSurfaceType::ALL)

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -22,11 +22,13 @@ use smithay::wayland::pointer_constraints::{PointerConstraint, with_pointer_cons
 use smithay::wayland::seat::WaylandFocus;
 
 use smithay::utils::Logical;
-use smithay::wayland::compositor::RegionAttributes;
+use smithay::wayland::compositor::{RegionAttributes, with_states};
 
 use std::rc::Rc;
+use std::sync::atomic::Ordering;
 
 use crate::decorations::{DecorationHit, DecorationKey};
+use crate::handlers::layer_shell::LayerDestroyedMarker;
 use crate::state::{DriftWm, FocusTarget, PickTarget, StageWindow, SuspendedWindow};
 use driftwm::canvas::{
     CanvasPos, ScreenPos, clamp_to_output, screen_space_focus_loc, screen_to_canvas,
@@ -2081,6 +2083,21 @@ impl DriftWm {
             // even though its bbox contains it, and the surface beneath must
             // still receive the input.
             for (surface, geo) in self.layers_on_sorted(&output, layer) {
+                // Skip a surface whose layer-shell role was destroyed but which
+                // is still listed in smithay's layer map until cleanup: its
+                // buffer geometry is stale, and hit-testing it would pin the
+                // pointer to a dead surface. `layer_destroyed` sets this marker
+                // before it recomputes pointer focus, so the recompute lands on
+                // whatever genuinely sits beneath the cursor.
+                let role_destroyed = with_states(surface.wl_surface(), |states| {
+                    states
+                        .data_map
+                        .get::<LayerDestroyedMarker>()
+                        .is_some_and(|m| m.0.load(Ordering::Relaxed))
+                });
+                if role_destroyed {
+                    continue;
+                }
                 let surface_local = screen_pos - geo.loc.to_f64();
                 if let Some((wl_surface, sub_loc)) =
                     surface.surface_under(surface_local, WindowSurfaceType::ALL)

--- a/src/state/fullscreen.rs
+++ b/src/state/fullscreen.rs
@@ -500,6 +500,14 @@ impl DriftWm {
                 self.warp_pointer(new_pos);
             }
         }
+
+        // Exiting fullscreen can restore a hidden bar beneath a stationary
+        // cursor; `pointer_over_layer` and smithay's focus are otherwise only
+        // refreshed by pointer motion, and a stale flag would route the next
+        // press/scroll over the bar to the canvas. Same plain-dispatch
+        // constraint as the warp above: this makes pointer calls, so no caller
+        // may sit inside a pointer-grab callback.
+        self.refresh_pointer_focus();
     }
 
     /// Tear down any fullscreen entry whose window is dead, restoring that

--- a/src/tests/layer_destroy_focus.rs
+++ b/src/tests/layer_destroy_focus.rs
@@ -1,9 +1,9 @@
-//! Pointer-focus invariants around layer-surface teardown: a layer destroyed
-//! beneath a stationary cursor must not leave `pointer_over_layer` stale, or
-//! the next press/scroll lands on the canvas instead of the surface still
-//! under the pointer. The compositor re-seats focus on the destroy itself;
-//! the hit-test must also skip the role-destroyed surface that is still
-//! listed in the layer map until render-time cleanup.
+//! Pointer-focus invariants when a layer appears or disappears under a
+//! stationary cursor: `pointer_over_layer` is only refreshed by pointer
+//! motion, so a layer destroyed (or revealed by a fullscreen exit) beneath a
+//! resting cursor would route the next press/scroll to the canvas instead of
+//! the layer surface under the pointer. The compositor re-seats focus on the
+//! scene change itself, and the tests pin the press to the correct grab.
 
 use driftwm::config::BTN_LEFT;
 use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
@@ -115,6 +115,21 @@ fn layer_destroyed_under_the_cursor_keeps_pointer_focus() {
     // in the default config). A press over a layer always installs a
     // ScreenSpaceClickGrab; a PanGrab is the stale-flag regression.
     press(&mut f, &device, BTN_LEFT);
+    assert_click_grab(
+        &mut f,
+        "the press after the teardown must hit the bar, not pan the canvas",
+    );
+    release(&mut f, &device, BTN_LEFT);
+
+    // Cleanup: the panel's wl_surface, then the bar's layer surface.
+    f.client(id).layer(&panel).surface.destroy();
+    f.client(id).layer(&bar).layer_surface.destroy();
+    f.double_roundtrip(id);
+}
+
+/// A layer press delivers a `ScreenSpaceClickGrab`; a `PanGrab` means the
+/// press fell through to the canvas. Pressed, not yet released.
+fn assert_click_grab(f: &mut Fixture, why: &str) {
     let (pan_grab, click_grab) = f
         .state()
         .seat
@@ -127,15 +142,69 @@ fn layer_destroyed_under_the_cursor_keeps_pointer_focus() {
             )
         })
         .unwrap_or((false, false));
+    assert_eq!((pan_grab, click_grab), (false, true), "{why}");
+}
+
+/// Exiting fullscreen can restore a hidden bar beneath a stationary cursor:
+/// `enter_fullscreen` forced `pointer_over_layer` to false and nothing
+/// refreshed it until the exit. The exit re-seats focus on the revealed bar.
+#[test]
+fn fullscreen_exit_reveals_a_bar_under_the_stationary_cursor() {
+    let mut f = Fixture::new();
+    f.add_output(1, (1920, 1080));
+    let id = f.add_client();
+    let device = FakeDevice::mouse();
+
+    let window_surface = super::map_window(&mut f, id, "w", (800, 600));
+    let output = f.state().active_output().unwrap();
+    let window = super::window_by_app_id(&mut f, "w").unwrap();
+
+    // The bar fullscreen hides and exit restores beneath the cursor.
+    let bar = map_layer(
+        &mut f,
+        id,
+        zwlr_layer_shell_v1::Layer::Top,
+        "bar",
+        (1920, 40),
+        zwlr_layer_surface_v1::Anchor::Bottom
+            | zwlr_layer_surface_v1::Anchor::Left
+            | zwlr_layer_surface_v1::Anchor::Right,
+    );
+
+    // Cursor over the bar's strip, then fullscreen over it.
+    let over_bar = Point::from((960.0, 1060.0));
+    pointer_to_screen(&mut f, &device, over_bar);
+    f.state().enter_fullscreen(&window, Some(output.clone()));
+    f.double_roundtrip(id);
+    super::adopt_last_configure(&mut f, id, &window_surface);
+
+    // The fullscreen window owns focus while it covers the bar.
     assert_eq!(
-        (pan_grab, click_grab),
-        (false, true),
-        "the press after the teardown must hit the bar, not pan the canvas"
+        pointer_focus(&mut f),
+        Some(super::server_surface(&window)),
+        "the fullscreen window owns focus while the bar is hidden beneath it"
+    );
+
+    // Exit with the cursor still over the bar's spot, no motion since.
+    f.state().exit_fullscreen_on(&output);
+    f.double_roundtrip(id);
+
+    let bar_server = layer_surface_by_namespace(&mut f, "bar");
+    assert_eq!(
+        pointer_focus(&mut f),
+        Some(bar_server),
+        "exiting fullscreen must re-seat focus on the bar revealed beneath the cursor"
+    );
+
+    press(&mut f, &device, BTN_LEFT);
+    assert_click_grab(
+        &mut f,
+        "the press must hit the bar, not the restored window",
     );
     release(&mut f, &device, BTN_LEFT);
 
-    // Cleanup: the panel's wl_surface, then the bar's layer surface.
-    f.client(id).layer(&panel).surface.destroy();
+    // Cleanup: the window, then the bar's layer surface.
+    f.client(id).window(&window_surface).destroy();
     f.client(id).layer(&bar).layer_surface.destroy();
     f.double_roundtrip(id);
 }

--- a/src/tests/layer_destroy_focus.rs
+++ b/src/tests/layer_destroy_focus.rs
@@ -1,8 +1,9 @@
 //! Pointer-focus invariants around layer-surface teardown: a layer destroyed
 //! beneath a stationary cursor must not leave `pointer_over_layer` stale, or
 //! the next press/scroll lands on the canvas instead of the surface still
-//! under the pointer (the noctalia bar closes its panel — a second layer — on
-//! the click that hits it, and the following click was panning the canvas).
+//! under the pointer. The compositor re-seats focus on the destroy itself;
+//! the hit-test must also skip the role-destroyed surface that is still
+//! listed in the layer map until render-time cleanup.
 
 use driftwm::config::BTN_LEFT;
 use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
@@ -54,8 +55,9 @@ fn map_layer(
     surface
 }
 
-/// dies on the bar's click. The cursor rests over the bar through the whole
-/// teardown; the next press must reach the bar again, not pan the canvas.
+/// A panel layer dies over a bar while the cursor rests on the bar. The next
+/// press — no pointer motion through the whole teardown — must reach the bar
+/// again, not pan the canvas.
 #[test]
 fn layer_destroyed_under_the_cursor_keeps_pointer_focus() {
     let mut f = Fixture::new();
@@ -63,8 +65,7 @@ fn layer_destroyed_under_the_cursor_keeps_pointer_focus() {
     let id = f.add_client();
     let device = FakeDevice::mouse();
 
-    // The bar: full-width bottom strip. No exclusive zone, like noctalia's
-    // `reserve_space = false`.
+    // The bar: full-width bottom strip with no exclusive zone.
     let bar = map_layer(
         &mut f,
         id,
@@ -76,8 +77,8 @@ fn layer_destroyed_under_the_cursor_keeps_pointer_focus() {
             | zwlr_layer_surface_v1::Anchor::Right,
     );
 
-    // The panel `open_near_click_session` opens over the bar: an Overlay layer
-    // covering the cursor's spot, above the bar in z-order.
+    // A covering layer above the bar, over the cursor's spot: a panel or OSD
+    // that opens anchored to the bar, and dies on the click that hits the bar.
     let panel = map_layer(
         &mut f,
         id,
@@ -98,7 +99,7 @@ fn layer_destroyed_under_the_cursor_keeps_pointer_focus() {
     );
 
     // The click that hits the bar closes the panel: layer-shell role first,
-    // wl_surface after (the teardown order a real panel uses).
+    // wl_surface after (the teardown order a real client uses).
     f.client(id).layer(&panel).layer_surface.destroy();
     f.double_roundtrip(id);
     assert_eq!(

--- a/src/tests/layer_destroy_focus.rs
+++ b/src/tests/layer_destroy_focus.rs
@@ -1,0 +1,140 @@
+//! Pointer-focus invariants around layer-surface teardown: a layer destroyed
+//! beneath a stationary cursor must not leave `pointer_over_layer` stale, or
+//! the next press/scroll lands on the canvas instead of the surface still
+//! under the pointer (the noctalia bar closes its panel — a second layer — on
+//! the click that hits it, and the following click was panning the canvas).
+
+use driftwm::config::BTN_LEFT;
+use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
+
+use super::input_backend::{pointer_to_screen, press, release};
+use super::{Fixture, client::LayerConfigureProps, input_backend::FakeDevice, pointer_focus};
+
+use smithay::utils::Point;
+
+/// Server-side surface of the layer with `namespace` on the first output.
+fn layer_surface_by_namespace(
+    f: &mut Fixture,
+    namespace: &str,
+) -> smithay::reexports::wayland_server::protocol::wl_surface::WlSurface {
+    let output = f.state().space.outputs().next().cloned().unwrap();
+    smithay::desktop::layer_map_for_output(&output)
+        .layers()
+        .find(|l| l.namespace() == namespace)
+        .unwrap()
+        .wl_surface()
+        .clone()
+}
+
+/// Map a layer, give it a buffer, and settle. Returns the client-side surface.
+fn map_layer(
+    f: &mut Fixture,
+    id: super::client::ClientId,
+    layer: zwlr_layer_shell_v1::Layer,
+    namespace: &str,
+    size: (u32, u32),
+    anchor: zwlr_layer_surface_v1::Anchor,
+) -> wayland_client::protocol::wl_surface::WlSurface {
+    let created = f.client(id).create_layer(None, layer, namespace);
+    let surface = created.surface.clone();
+    created.set_configure_props(LayerConfigureProps {
+        size: Some(size),
+        anchor: Some(anchor),
+        exclusive_zone: Some(0),
+        ..Default::default()
+    });
+    created.commit();
+    f.roundtrip(id);
+
+    let layer = f.client(id).layer(&surface);
+    layer.set_size(size.0 as u16, size.1 as u16);
+    layer.attach_new_buffer();
+    layer.ack_last_and_commit();
+    f.double_roundtrip(id);
+    surface
+}
+
+/// dies on the bar's click. The cursor rests over the bar through the whole
+/// teardown; the next press must reach the bar again, not pan the canvas.
+#[test]
+fn layer_destroyed_under_the_cursor_keeps_pointer_focus() {
+    let mut f = Fixture::new();
+    f.add_output(1, (1920, 1080));
+    let id = f.add_client();
+    let device = FakeDevice::mouse();
+
+    // The bar: full-width bottom strip. No exclusive zone, like noctalia's
+    // `reserve_space = false`.
+    let bar = map_layer(
+        &mut f,
+        id,
+        zwlr_layer_shell_v1::Layer::Top,
+        "bar",
+        (1920, 40),
+        zwlr_layer_surface_v1::Anchor::Bottom
+            | zwlr_layer_surface_v1::Anchor::Left
+            | zwlr_layer_surface_v1::Anchor::Right,
+    );
+
+    // The panel `open_near_click_session` opens over the bar: an Overlay layer
+    // covering the cursor's spot, above the bar in z-order.
+    let panel = map_layer(
+        &mut f,
+        id,
+        zwlr_layer_shell_v1::Layer::Overlay,
+        "panel",
+        (400, 600),
+        zwlr_layer_surface_v1::Anchor::Bottom,
+    );
+
+    let over_bar = Point::from((960.0, 1060.0));
+    pointer_to_screen(&mut f, &device, over_bar);
+    let bar_server = layer_surface_by_namespace(&mut f, "bar");
+    let panel_server = layer_surface_by_namespace(&mut f, "panel");
+    assert_eq!(
+        pointer_focus(&mut f),
+        Some(panel_server),
+        "the panel sits over the cursor's spot, so it owns focus while alive"
+    );
+
+    // The click that hits the bar closes the panel: layer-shell role first,
+    // wl_surface after (the teardown order a real panel uses).
+    f.client(id).layer(&panel).layer_surface.destroy();
+    f.double_roundtrip(id);
+    assert_eq!(
+        pointer_focus(&mut f),
+        Some(bar_server.clone()),
+        "focus must be re-seated on the bar beneath, not left on the dead \
+         panel (still listed in the layer map until cleanup) and not dropped \
+         to the canvas"
+    );
+
+    // The next press, still without pointer motion, must reach the bar again —
+    // not pan the canvas (unbound BTN_LEFT on the empty canvas is PanViewport
+    // in the default config). A press over a layer always installs a
+    // ScreenSpaceClickGrab; a PanGrab is the stale-flag regression.
+    press(&mut f, &device, BTN_LEFT);
+    let (pan_grab, click_grab) = f
+        .state()
+        .seat
+        .get_pointer()
+        .unwrap()
+        .with_grab(|_, g| {
+            (
+                g.is::<crate::grabs::PanGrab>(),
+                g.is::<crate::grabs::ScreenSpaceClickGrab>(),
+            )
+        })
+        .unwrap_or((false, false));
+    assert_eq!(
+        (pan_grab, click_grab),
+        (false, true),
+        "the press after the teardown must hit the bar, not pan the canvas"
+    );
+    release(&mut f, &device, BTN_LEFT);
+
+    // Cleanup: the panel's wl_surface, then the bar's layer surface.
+    f.client(id).layer(&panel).surface.destroy();
+    f.client(id).layer(&bar).layer_surface.destroy();
+    f.double_roundtrip(id);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -36,6 +36,7 @@ mod hotplug;
 mod hover_focus;
 mod input_dispatch;
 mod interact_min;
+mod layer_destroy_focus;
 mod opacity;
 mod pinned_phantom;
 mod popups;


### PR DESCRIPTION
## Before
`pointer_over_layer` was always (unconditionally) being reset to `false` if any layer was destroyed. It was being updated by `focus_cascade` on mouse movement, so the state was frozen as false until next mouse movement.

### Case with Noctalias bar
https://github.com/user-attachments/assets/eed496cc-6277-4705-878a-cce6ed24c743

## After
Instead of resetting `pointer_over_layer` we are refreshing it via `refresh_pointer_focus()`

### Case with Noctalias bar
https://github.com/user-attachments/assets/d2830ccc-e29d-4453-aee9-eff7ba5b1ef1

## Other fixes related to this
### Filter inside of `layer_surface_under`
Skip layers with the `LayerDestroyedMarker` in hit test

### Fullscreen behavior fix
`enter_fullscreen` sets `pointer_over_layer` to `false`, and `exit_fullscreen_on` was restoring everything (camera, zoom, etc.) but `pointer_over_layer` - it was left as `false`. Now it refreshes it via `refresh_pointer_focus()`

### Regression test
src/tests/layer_destroy_focus.rs - test focus after destroying the layer the cursor was pointing at