### PR TITLE
feat: Add 'toggle-touchpad' action support

### DIFF
--- a/config.reference.toml
+++ b/config.reference.toml
@@ -341,7 +341,7 @@
 # #   toggle-pin-to-screen    — pin/unpin the focused window to the screen (ignores pan/zoom, floats above)
 # #   reload-config           — hot-reload config file
 # #   toggle-cursor-pan       — toggle cursor edge-pan (see [navigation.edge_pan])
-# #   toggle-touchpad [on|off] — set the built-in touchpad enabled/disabled, or toggle (libinput send-events mode)
+# #   set-trackpad on|off|toggle — set the built-in trackpad enabled/disabled, or toggle (libinput send-events mode)
 # #   quit                    — exit the compositor
 # #   send-to-output <dir>    — move focused window to adjacent output
 # #   send-cursor-to-output <dir>  — move the cursor to adjacent output
@@ -414,9 +414,9 @@
 # # "mod+g" = "fill-window"
 # # Example: suspend-window (unbound by default)
 # # "mod+s" = "suspend-window"
-# # Example: toggle-touchpad (unbound by default)
-# # "mod+f10" = "toggle-touchpad"   # toggle the built-in touchpad on/off (e.g. with an external mouse attached)
-# # "mod+shift+f10" = "toggle-touchpad off"   # force the touchpad off (e.g. for per-window rules)
+# # Example: set-trackpad (unbound by default)
+# # "mod+f10" = "set-trackpad toggle"   # toggle the built-in trackpad on/off (e.g. with an external mouse attached)
+# # "mod+shift+f10" = "set-trackpad off"   # force the trackpad off (e.g. for per-window rules)
 
 [mouse]
 # # When true (default), dragging a window's edge or corner resizes it via the

--- a/config.reference.toml
+++ b/config.reference.toml
@@ -341,7 +341,7 @@
 # #   toggle-pin-to-screen    — pin/unpin the focused window to the screen (ignores pan/zoom, floats above)
 # #   reload-config           — hot-reload config file
 # #   toggle-cursor-pan       — toggle cursor edge-pan (see [navigation.edge_pan])
-# #   toggle-touchpad         — toggle the built-in touchpad on/off (libinput send-events mode)
+# #   toggle-touchpad [on|off] — set the built-in touchpad enabled/disabled, or toggle (libinput send-events mode)
 # #   quit                    — exit the compositor
 # #   send-to-output <dir>    — move focused window to adjacent output
 # #   send-cursor-to-output <dir>  — move the cursor to adjacent output
@@ -416,6 +416,7 @@
 # # "mod+s" = "suspend-window"
 # # Example: toggle-touchpad (unbound by default)
 # # "mod+f10" = "toggle-touchpad"   # toggle the built-in touchpad on/off (e.g. with an external mouse attached)
+# # "mod+shift+f10" = "toggle-touchpad off"   # force the touchpad off (e.g. for per-window rules)
 
 [mouse]
 # # When true (default), dragging a window's edge or corner resizes it via the

--- a/config.reference.toml
+++ b/config.reference.toml
@@ -341,6 +341,7 @@
 # #   toggle-pin-to-screen    — pin/unpin the focused window to the screen (ignores pan/zoom, floats above)
 # #   reload-config           — hot-reload config file
 # #   toggle-cursor-pan       — toggle cursor edge-pan (see [navigation.edge_pan])
+# #   toggle-touchpad         — toggle the built-in touchpad on/off (libinput send-events mode)
 # #   quit                    — exit the compositor
 # #   send-to-output <dir>    — move focused window to adjacent output
 # #   send-cursor-to-output <dir>  — move the cursor to adjacent output
@@ -413,6 +414,8 @@
 # # "mod+g" = "fill-window"
 # # Example: suspend-window (unbound by default)
 # # "mod+s" = "suspend-window"
+# # Example: toggle-touchpad (unbound by default)
+# # "mod+f10" = "toggle-touchpad"   # toggle the built-in touchpad on/off (e.g. with an external mouse attached)
 
 [mouse]
 # # When true (default), dragging a window's edge or corner resizes it via the

--- a/docs/config.md
+++ b/docs/config.md
@@ -705,7 +705,7 @@ Actions:
 - `toggle-pin-to-screen` — pin/unpin the focused window to the screen (ignores pan/zoom, floats above)
 - `reload-config` — hot-reload config file
 - `toggle-cursor-pan` — toggle cursor edge-pan (see [navigation.edge_pan])
-- `toggle-touchpad` — toggle the built-in touchpad on/off (libinput send-events mode)
+- `toggle-touchpad [on|off]` — set the built-in touchpad enabled/disabled, or toggle (libinput send-events mode)
 - `quit` — exit the compositor
 - `send-to-output <dir>` — move focused window to adjacent output
 - `send-cursor-to-output <dir>` — move the cursor to adjacent output
@@ -802,6 +802,7 @@ Directions: up, down, left, right, up-left, up-right, down-left, down-right
 
 ```toml
 "mod+f10" = "toggle-touchpad"   # toggle the built-in touchpad on/off (e.g. with an external mouse attached)
+"mod+shift+f10" = "toggle-touchpad off"   # force the touchpad off (e.g. for per-window rules)
 ```
 
 ## `[mouse]`

--- a/docs/config.md
+++ b/docs/config.md
@@ -705,7 +705,7 @@ Actions:
 - `toggle-pin-to-screen` — pin/unpin the focused window to the screen (ignores pan/zoom, floats above)
 - `reload-config` — hot-reload config file
 - `toggle-cursor-pan` — toggle cursor edge-pan (see [navigation.edge_pan])
-- `toggle-touchpad [on|off]` — set the built-in touchpad enabled/disabled, or toggle (libinput send-events mode)
+- `set-trackpad on|off|toggle` — set the built-in trackpad enabled/disabled, or toggle (libinput send-events mode)
 - `quit` — exit the compositor
 - `send-to-output <dir>` — move focused window to adjacent output
 - `send-cursor-to-output <dir>` — move the cursor to adjacent output
@@ -798,11 +798,11 @@ Directions: up, down, left, right, up-left, up-right, down-left, down-right
 "mod+s" = "suspend-window"
 ```
 
-**Example: toggle-touchpad (unbound by default)**
+**Example: set-trackpad (unbound by default)**
 
 ```toml
-"mod+f10" = "toggle-touchpad"   # toggle the built-in touchpad on/off (e.g. with an external mouse attached)
-"mod+shift+f10" = "toggle-touchpad off"   # force the touchpad off (e.g. for per-window rules)
+"mod+f10" = "set-trackpad toggle"   # toggle the built-in trackpad on/off (e.g. with an external mouse attached)
+"mod+shift+f10" = "set-trackpad off"   # force the trackpad off (e.g. for per-window rules)
 ```
 
 ## `[mouse]`

--- a/docs/config.md
+++ b/docs/config.md
@@ -705,6 +705,7 @@ Actions:
 - `toggle-pin-to-screen` — pin/unpin the focused window to the screen (ignores pan/zoom, floats above)
 - `reload-config` — hot-reload config file
 - `toggle-cursor-pan` — toggle cursor edge-pan (see [navigation.edge_pan])
+- `toggle-touchpad` — toggle the built-in touchpad on/off (libinput send-events mode)
 - `quit` — exit the compositor
 - `send-to-output <dir>` — move focused window to adjacent output
 - `send-cursor-to-output <dir>` — move the cursor to adjacent output
@@ -795,6 +796,12 @@ Directions: up, down, left, right, up-left, up-right, down-left, down-right
 
 ```toml
 "mod+s" = "suspend-window"
+```
+
+**Example: toggle-touchpad (unbound by default)**
+
+```toml
+"mod+f10" = "toggle-touchpad"   # toggle the built-in touchpad on/off (e.g. with an external mouse attached)
 ```
 
 ## `[mouse]`

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -191,7 +191,19 @@ pub fn parse_action(s: &str) -> Result<Action, String> {
         "toggle-pin-to-screen" => Ok(Action::TogglePinToScreen),
         "reload-config" => Ok(Action::ReloadConfig),
         "toggle-cursor-pan" => Ok(Action::ToggleCursorPan),
-        "toggle-touchpad" => Ok(Action::ToggleTouchpad),
+        "toggle-touchpad" => {
+            let state = match arg {
+                None => TouchpadState::Toggle,
+                Some(a) if a.eq_ignore_ascii_case("on") => TouchpadState::On,
+                Some(a) if a.eq_ignore_ascii_case("off") => TouchpadState::Off,
+                Some(other) => {
+                    return Err(format!(
+                        "toggle-touchpad: expected on, off, or no argument, got '{other}'"
+                    ));
+                }
+            };
+            Ok(Action::SetTouchpad(state))
+        }
         "quit" => Ok(Action::Quit),
         other => Err(format!("unknown action: {other}")),
     }
@@ -602,7 +614,7 @@ mod tests {
             Action::SwitchLayout(_) => "switch-layout",
             Action::ReloadConfig => "reload-config",
             Action::ToggleCursorPan => "toggle-cursor-pan",
-            Action::ToggleTouchpad => "toggle-touchpad",
+            Action::SetTouchpad(_) => "toggle-touchpad",
             Action::Quit => "quit",
         }
     }
@@ -644,6 +656,27 @@ mod tests {
                 "sample {sample:?} parsed to a variant whose name is not {name:?}"
             );
         }
+    }
+
+    #[test]
+    fn toggle_touchpad_parses_with_optional_state() {
+        assert_eq!(
+            parse_action("toggle-touchpad"),
+            Ok(Action::SetTouchpad(TouchpadState::Toggle))
+        );
+        assert_eq!(
+            parse_action("toggle-touchpad on"),
+            Ok(Action::SetTouchpad(TouchpadState::On))
+        );
+        assert_eq!(
+            parse_action("toggle-touchpad OFF"),
+            Ok(Action::SetTouchpad(TouchpadState::Off))
+        );
+        assert_eq!(
+            parse_action(" toggle-touchpad off "),
+            Ok(Action::SetTouchpad(TouchpadState::Off))
+        );
+        assert!(parse_action("toggle-touchpad maybe").is_err());
     }
 
     #[test]

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -191,6 +191,7 @@ pub fn parse_action(s: &str) -> Result<Action, String> {
         "toggle-pin-to-screen" => Ok(Action::TogglePinToScreen),
         "reload-config" => Ok(Action::ReloadConfig),
         "toggle-cursor-pan" => Ok(Action::ToggleCursorPan),
+        "toggle-touchpad" => Ok(Action::ToggleTouchpad),
         "quit" => Ok(Action::Quit),
         other => Err(format!("unknown action: {other}")),
     }
@@ -227,6 +228,7 @@ pub const ACTION_NAMES: &[(&str, &str)] = &[
     ("toggle-cursor-pan", "toggle-cursor-pan"),
     ("toggle-fullscreen", "toggle-fullscreen"),
     ("toggle-pin-to-screen", "toggle-pin-to-screen"),
+    ("toggle-touchpad", "toggle-touchpad"),
     ("zoom-in", "zoom-in"),
     ("zoom-out", "zoom-out"),
     ("zoom-reset", "zoom-reset"),
@@ -600,6 +602,7 @@ mod tests {
             Action::SwitchLayout(_) => "switch-layout",
             Action::ReloadConfig => "reload-config",
             Action::ToggleCursorPan => "toggle-cursor-pan",
+            Action::ToggleTouchpad => "toggle-touchpad",
             Action::Quit => "quit",
         }
     }

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -191,18 +191,19 @@ pub fn parse_action(s: &str) -> Result<Action, String> {
         "toggle-pin-to-screen" => Ok(Action::TogglePinToScreen),
         "reload-config" => Ok(Action::ReloadConfig),
         "toggle-cursor-pan" => Ok(Action::ToggleCursorPan),
-        "toggle-touchpad" => {
+        "set-trackpad" => {
             let state = match arg {
-                None => TouchpadState::Toggle,
-                Some(a) if a.eq_ignore_ascii_case("on") => TouchpadState::On,
-                Some(a) if a.eq_ignore_ascii_case("off") => TouchpadState::Off,
+                None => return Err("set-trackpad requires on, off, or toggle".to_string()),
+                Some(a) if a.eq_ignore_ascii_case("on") => TrackpadState::On,
+                Some(a) if a.eq_ignore_ascii_case("off") => TrackpadState::Off,
+                Some(a) if a.eq_ignore_ascii_case("toggle") => TrackpadState::Toggle,
                 Some(other) => {
                     return Err(format!(
-                        "toggle-touchpad: expected on, off, or no argument, got '{other}'"
+                        "set-trackpad: expected on, off, or toggle, got '{other}'"
                     ));
                 }
             };
-            Ok(Action::SetTouchpad(state))
+            Ok(Action::SetTrackpad(state))
         }
         "quit" => Ok(Action::Quit),
         other => Err(format!("unknown action: {other}")),
@@ -240,7 +241,7 @@ pub const ACTION_NAMES: &[(&str, &str)] = &[
     ("toggle-cursor-pan", "toggle-cursor-pan"),
     ("toggle-fullscreen", "toggle-fullscreen"),
     ("toggle-pin-to-screen", "toggle-pin-to-screen"),
-    ("toggle-touchpad", "toggle-touchpad"),
+    ("set-trackpad", "set-trackpad toggle"),
     ("zoom-in", "zoom-in"),
     ("zoom-out", "zoom-out"),
     ("zoom-reset", "zoom-reset"),
@@ -614,7 +615,7 @@ mod tests {
             Action::SwitchLayout(_) => "switch-layout",
             Action::ReloadConfig => "reload-config",
             Action::ToggleCursorPan => "toggle-cursor-pan",
-            Action::SetTouchpad(_) => "toggle-touchpad",
+            Action::SetTrackpad(_) => "set-trackpad",
             Action::Quit => "quit",
         }
     }
@@ -659,24 +660,25 @@ mod tests {
     }
 
     #[test]
-    fn toggle_touchpad_parses_with_optional_state() {
+    fn set_trackpad_parses_with_explicit_state() {
         assert_eq!(
-            parse_action("toggle-touchpad"),
-            Ok(Action::SetTouchpad(TouchpadState::Toggle))
+            parse_action("set-trackpad on"),
+            Ok(Action::SetTrackpad(TrackpadState::On))
         );
         assert_eq!(
-            parse_action("toggle-touchpad on"),
-            Ok(Action::SetTouchpad(TouchpadState::On))
+            parse_action("set-trackpad OFF"),
+            Ok(Action::SetTrackpad(TrackpadState::Off))
         );
         assert_eq!(
-            parse_action("toggle-touchpad OFF"),
-            Ok(Action::SetTouchpad(TouchpadState::Off))
+            parse_action(" set-trackpad off "),
+            Ok(Action::SetTrackpad(TrackpadState::Off))
         );
         assert_eq!(
-            parse_action(" toggle-touchpad off "),
-            Ok(Action::SetTouchpad(TouchpadState::Off))
+            parse_action("set-trackpad toGGle"),
+            Ok(Action::SetTrackpad(TrackpadState::Toggle))
         );
-        assert!(parse_action("toggle-touchpad maybe").is_err());
+        assert!(parse_action("set-trackpad maybe").is_err());
+        assert!(parse_action("set-trackpad").is_err());
     }
 
     #[test]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -78,6 +78,7 @@ pub enum Action {
     SwitchLayout(LayoutSwitch),
     ReloadConfig,
     ToggleCursorPan,
+    ToggleTouchpad,
     Quit,
 }
 
@@ -105,6 +106,7 @@ impl Action {
                 | Action::ReloadConfig
                 | Action::SwitchLayout(_)
                 | Action::ToggleCursorPan
+                | Action::ToggleTouchpad
                 | Action::SendToOutput(_)
         )
     }
@@ -1251,6 +1253,7 @@ mod tests {
         assert!(Action::ReloadConfig.runs_during_fullscreen());
         assert!(Action::SwitchLayout(LayoutSwitch::Next).runs_during_fullscreen());
         assert!(Action::ToggleCursorPan.runs_during_fullscreen());
+        assert!(Action::ToggleTouchpad.runs_during_fullscreen());
         assert!(Action::SendToOutput(Direction::Right).runs_during_fullscreen());
         assert!(!Action::CloseWindow.runs_during_fullscreen());
         assert!(!Action::ZoomIn.runs_during_fullscreen());

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -78,8 +78,19 @@ pub enum Action {
     SwitchLayout(LayoutSwitch),
     ReloadConfig,
     ToggleCursorPan,
-    ToggleTouchpad,
+    SetTouchpad(TouchpadState),
     Quit,
+}
+
+/// Desired touchpad send-events state, as set by `toggle-touchpad`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TouchpadState {
+    /// Flip between enabled and disabled.
+    Toggle,
+    /// Force the touchpad enabled.
+    On,
+    /// Force the touchpad disabled.
+    Off,
 }
 
 impl Action {
@@ -106,7 +117,7 @@ impl Action {
                 | Action::ReloadConfig
                 | Action::SwitchLayout(_)
                 | Action::ToggleCursorPan
-                | Action::ToggleTouchpad
+                | Action::SetTouchpad(_)
                 | Action::SendToOutput(_)
         )
     }
@@ -1253,7 +1264,7 @@ mod tests {
         assert!(Action::ReloadConfig.runs_during_fullscreen());
         assert!(Action::SwitchLayout(LayoutSwitch::Next).runs_during_fullscreen());
         assert!(Action::ToggleCursorPan.runs_during_fullscreen());
-        assert!(Action::ToggleTouchpad.runs_during_fullscreen());
+        assert!(Action::SetTouchpad(TouchpadState::Toggle).runs_during_fullscreen());
         assert!(Action::SendToOutput(Direction::Right).runs_during_fullscreen());
         assert!(!Action::CloseWindow.runs_during_fullscreen());
         assert!(!Action::ZoomIn.runs_during_fullscreen());

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -78,18 +78,18 @@ pub enum Action {
     SwitchLayout(LayoutSwitch),
     ReloadConfig,
     ToggleCursorPan,
-    SetTouchpad(TouchpadState),
+    SetTrackpad(TrackpadState),
     Quit,
 }
 
-/// Desired touchpad send-events state, as set by `toggle-touchpad`.
+/// Desired trackpad send-events state, as set by `set-trackpad`.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TouchpadState {
+pub enum TrackpadState {
     /// Flip between enabled and disabled.
     Toggle,
-    /// Force the touchpad enabled.
+    /// Force the trackpad enabled.
     On,
-    /// Force the touchpad disabled.
+    /// Force the trackpad disabled.
     Off,
 }
 
@@ -117,7 +117,7 @@ impl Action {
                 | Action::ReloadConfig
                 | Action::SwitchLayout(_)
                 | Action::ToggleCursorPan
-                | Action::SetTouchpad(_)
+                | Action::SetTrackpad(_)
                 | Action::SendToOutput(_)
         )
     }
@@ -1264,7 +1264,7 @@ mod tests {
         assert!(Action::ReloadConfig.runs_during_fullscreen());
         assert!(Action::SwitchLayout(LayoutSwitch::Next).runs_during_fullscreen());
         assert!(Action::ToggleCursorPan.runs_during_fullscreen());
-        assert!(Action::SetTouchpad(TouchpadState::Toggle).runs_during_fullscreen());
+        assert!(Action::SetTrackpad(TrackpadState::Toggle).runs_during_fullscreen());
         assert!(Action::SendToOutput(Direction::Right).runs_during_fullscreen());
         assert!(!Action::CloseWindow.runs_during_fullscreen());
         assert!(!Action::ZoomIn.runs_during_fullscreen());

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -7,7 +7,7 @@ use smithay::{
 use crate::state::window_animation::{AnimSpace, ContentPolicy, GeometryRole};
 use crate::state::{DriftWm, HomeReturn, StageWindow};
 use driftwm::canvas::{self};
-use driftwm::config::{Action, LayoutSwitch, Modifiers, TouchpadState};
+use driftwm::config::{Action, LayoutSwitch, Modifiers, TrackpadState};
 use driftwm::window_ext::WindowExt;
 
 /// Use the focused window as the cone-search origin only when it's fully
@@ -658,7 +658,7 @@ impl DriftWm {
                     }
                 }
             }
-            Action::SetTouchpad(state) => self.set_touchpad(state),
+            Action::SetTrackpad(state) => self.set_trackpad(state),
             Action::Quit => {
                 tracing::info!("Quit action triggered — stopping compositor");
                 self.loop_signal.stop();
@@ -792,11 +792,11 @@ impl DriftWm {
         self.refresh_pointer_focus();
     }
 
-    /// Set every connected touchpad's libinput send-events mode — enabled,
+    /// Set every connected trackpad's libinput send-events mode — enabled,
     /// disabled, or toggled from its current state. The set state survives a
     /// config reload — hotplug/reload configuration (`configure_libinput_device`)
     /// never touches send-events mode.
-    fn set_touchpad(&mut self, state: &TouchpadState) {
+    fn set_trackpad(&mut self, state: &TrackpadState) {
         let mut found = false;
         for device in &self.input_devices {
             if device.config_tap_finger_count() == 0 {
@@ -804,9 +804,9 @@ impl DriftWm {
             }
             found = true;
             let target = match state {
-                TouchpadState::On => smithay::reexports::input::SendEventsMode::ENABLED,
-                TouchpadState::Off => smithay::reexports::input::SendEventsMode::DISABLED,
-                TouchpadState::Toggle => {
+                TrackpadState::On => smithay::reexports::input::SendEventsMode::ENABLED,
+                TrackpadState::Off => smithay::reexports::input::SendEventsMode::DISABLED,
+                TrackpadState::Toggle => {
                     // Only a true DISABLED state toggles back on.
                     // DISABLED_ON_EXTERNAL_MOUSE reads as "not disabled", so a
                     // toggle press goes fully off from there too.
@@ -825,7 +825,7 @@ impl DriftWm {
             }
         }
         if !found {
-            tracing::info!("toggle-touchpad: no touchpad connected (wanted {state:?})");
+            tracing::info!("set-trackpad: no trackpad connected (wanted {state:?})");
         }
     }
 

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -7,7 +7,7 @@ use smithay::{
 use crate::state::window_animation::{AnimSpace, ContentPolicy, GeometryRole};
 use crate::state::{DriftWm, HomeReturn, StageWindow};
 use driftwm::canvas::{self};
-use driftwm::config::{Action, LayoutSwitch, Modifiers};
+use driftwm::config::{Action, LayoutSwitch, Modifiers, TouchpadState};
 use driftwm::window_ext::WindowExt;
 
 /// Use the focused window as the cone-search origin only when it's fully
@@ -658,7 +658,7 @@ impl DriftWm {
                     }
                 }
             }
-            Action::ToggleTouchpad => self.toggle_touchpad(),
+            Action::SetTouchpad(state) => self.set_touchpad(state),
             Action::Quit => {
                 tracing::info!("Quit action triggered — stopping compositor");
                 self.loop_signal.stop();
@@ -792,33 +792,40 @@ impl DriftWm {
         self.refresh_pointer_focus();
     }
 
-    /// Toggle the touchpad's libinput send-events mode between enabled and
-    /// disabled, on every connected touchpad. The disabled state survives a
+    /// Set every connected touchpad's libinput send-events mode — enabled,
+    /// disabled, or toggled from its current state. The set state survives a
     /// config reload — hotplug/reload configuration (`configure_libinput_device`)
     /// never touches send-events mode.
-    fn toggle_touchpad(&mut self) {
+    fn set_touchpad(&mut self, state: &TouchpadState) {
         let mut found = false;
         for device in &self.input_devices {
             if device.config_tap_finger_count() == 0 {
                 continue;
             }
             found = true;
-            // Only a true DISABLED state toggles back on. DISABLED_ON_EXTERNAL_MOUSE
-            // reads as "not disabled", so the press goes fully off from there too.
-            let target = if device
-                .config_send_events_mode()
-                .contains(smithay::reexports::input::SendEventsMode::DISABLED)
-            {
-                smithay::reexports::input::SendEventsMode::ENABLED
-            } else {
-                smithay::reexports::input::SendEventsMode::DISABLED
+            let target = match state {
+                TouchpadState::On => smithay::reexports::input::SendEventsMode::ENABLED,
+                TouchpadState::Off => smithay::reexports::input::SendEventsMode::DISABLED,
+                TouchpadState::Toggle => {
+                    // Only a true DISABLED state toggles back on.
+                    // DISABLED_ON_EXTERNAL_MOUSE reads as "not disabled", so a
+                    // toggle press goes fully off from there too.
+                    if device
+                        .config_send_events_mode()
+                        .contains(smithay::reexports::input::SendEventsMode::DISABLED)
+                    {
+                        smithay::reexports::input::SendEventsMode::ENABLED
+                    } else {
+                        smithay::reexports::input::SendEventsMode::DISABLED
+                    }
+                }
             };
             if let Err(e) = device.config_send_events_set_mode(target) {
                 tracing::warn!("Failed to set send_events mode on {}: {e:?}", device.name());
             }
         }
         if !found {
-            tracing::info!("toggle-touchpad: no touchpad connected");
+            tracing::info!("toggle-touchpad: no touchpad connected (wanted {state:?})");
         }
     }
 

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -658,6 +658,7 @@ impl DriftWm {
                     }
                 }
             }
+            Action::ToggleTouchpad => self.toggle_touchpad(),
             Action::Quit => {
                 tracing::info!("Quit action triggered — stopping compositor");
                 self.loop_signal.stop();
@@ -789,6 +790,36 @@ impl DriftWm {
         }
         // The hit-test path changed (pinned vs canvas); recompute pointer focus.
         self.refresh_pointer_focus();
+    }
+
+    /// Toggle the touchpad's libinput send-events mode between enabled and
+    /// disabled, on every connected touchpad. The disabled state survives a
+    /// config reload — hotplug/reload configuration (`configure_libinput_device`)
+    /// never touches send-events mode.
+    fn toggle_touchpad(&mut self) {
+        let mut found = false;
+        for device in &self.input_devices {
+            if device.config_tap_finger_count() == 0 {
+                continue;
+            }
+            found = true;
+            // Only a true DISABLED state toggles back on. DISABLED_ON_EXTERNAL_MOUSE
+            // reads as "not disabled", so the press goes fully off from there too.
+            let target = if device
+                .config_send_events_mode()
+                .contains(smithay::reexports::input::SendEventsMode::DISABLED)
+            {
+                smithay::reexports::input::SendEventsMode::ENABLED
+            } else {
+                smithay::reexports::input::SendEventsMode::DISABLED
+            };
+            if let Err(e) = device.config_send_events_set_mode(target) {
+                tracing::warn!("Failed to set send_events mode on {}: {e:?}", device.name());
+            }
+        }
+        if !found {
+            tracing::info!("toggle-touchpad: no touchpad connected");
+        }
     }
 
     /// If an overview-return is pending, animate back to it and return true.


### PR DESCRIPTION
## Add 'toggle-touchpad' action support for disabling/enabling built-in touchpad, update tests and docs.
### Usage:
- driftwm msg action toggle-touchpad -- toggles the touchpad state between disabled and enabled
- driftwm msg action toggle-touchpad on -- enables it
- driftwm msg action toggle-touchpad off -- disables it