### PR TITLE
fix: session store live windows, preventing the race between the compositor and it's clients

### DIFF
--- a/src/grabs/move_grab.rs
+++ b/src/grabs/move_grab.rs
@@ -455,9 +455,12 @@ impl PointerGrab<DriftWm> for MoveGrab {
         // Both arms armed `interactive_move` at grab install (guarding relaunch
         // adoption and animation starts); balance it here.
         data.disarm_interactive_move(&self.target);
-        // A stand-in's settled position (including a cross-output teleport) is
-        // durable — persist it on the session-store debounce.
-        if matches!(self.target, ClusterMember::Suspended(_)) {
+        // A settled position (including a cross-output teleport) is durable —
+        // persist it on the session-store debounce, live or stand-in alike.
+        if matches!(
+            self.target,
+            ClusterMember::Client(_) | ClusterMember::Suspended(_)
+        ) {
             data.session_store_mark_dirty();
         }
         // A pick-mode promote is the only move that sets grab_cursor (title-bar

--- a/src/grabs/resize_grab.rs
+++ b/src/grabs/resize_grab.rs
@@ -357,6 +357,9 @@ impl PointerGrab<DriftWm> for ResizeGrab {
                 // hands back a view move this grab held off — the stand-in arm's
                 // disarm does that for itself.
                 data.flush_deferred_views();
+                // The settled size (and the commit-time reposition that follows
+                // it) is durable — persist it on the session-store debounce.
+                data.session_store_mark_dirty();
             }
             ClusterMember::Suspended(id) => {
                 data.disarm_interactive_move(id);

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -1136,7 +1136,22 @@ impl DriftWm {
                 initial_screen_pos,
                 last_committed_size,
             } => (edges, initial_screen_pos, last_committed_size),
-            ResizeState::Idle => return,
+            ResizeState::Idle => {
+                // A step/IPC resize (`msg resize`, grow/shrink) never arms
+                // `ResizeState` — it writes a `PendingResize` and a plain sized
+                // configure — so its answering commit is the only seam where the
+                // durable size actually lands. Mark it like the grab path's
+                // settle does, so a crash after the request restores the new
+                // size, not the pre-resize one.
+                if self
+                    .pending_resizes
+                    .get(&surface.id())
+                    .is_some_and(|r| r.is_live(window))
+                {
+                    self.session_store_mark_dirty();
+                }
+                return;
+            }
         };
 
         let current_geo = window.geometry();

--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -818,6 +818,9 @@ impl CompositorHandler for DriftWm {
                             // the body size the client hasn't acked yet, so it
                             // establishes a stable rect on its next settle.
                             self.refresh_stable_snap_rect(&StageWindow::Client(window.clone()));
+                            // The resize settled: its size — and any top/left reposition above
+                            // — is durable, so persist it on the session-store debounce.
+                            self.session_store_mark_dirty();
                             // Scale+fade the window in. A window opening straight
                             // into fullscreen/fit runs both in this same commit,
                             // so this entry is never drawn: the geometry entry

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -71,6 +71,10 @@ impl XdgShellHandler for DriftWm {
         self.map_window(window.clone(), pos.into(), false);
         self.raise_window(&window, false);
         self.enforce_below_windows();
+        // A new live window must land in the durable session: the debounced
+        // flush now records live windows, so a crash or SIGKILL after this
+        // point restores it instead of a shutdown race deciding its fate.
+        self.session_store_mark_dirty();
         // Don't focus here: a pre-buffer wl_keyboard.enter is unusable, and
         // set_focus is a no-op when the target is unchanged, so focusing now
         // would trap the client unfocused (the on-commit re-focus does nothing).
@@ -392,6 +396,9 @@ impl XdgShellHandler for DriftWm {
                 self.snapshot_closing_window(window, &wl_surface, fs_output.as_ref(), false);
             }
             self.unmap_window(window);
+            // The window left the stage; the durable record must follow, or a
+            // stale flush could re-save a window the user closed minutes ago.
+            self.session_store_mark_dirty();
             // The window may have sat under the cursor; re-target pointer focus
             // now that it's gone so clicks don't fall into the destroyed surface.
             self.refresh_pointer_focus();

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -102,12 +102,9 @@ impl DriftWm {
                     self.drop_owed_recenter(&element);
                     self.map_window(element.clone(), new_loc, false);
                     self.animate_element_move_from(&element, loc, None);
-                    // A stand-in's canvas position is durable — persist the
-                    // nudge on the session-store debounce (the client arm stays
-                    // unmarked).
-                    if matches!(element, StageWindow::Suspended(_)) {
-                        self.session_store_mark_dirty();
-                    }
+                    // The element's canvas position is durable — persist the
+                    // nudge on the session-store debounce.
+                    self.session_store_mark_dirty();
                 }
             }
             Action::GrowWindow(dir) => self.step_resize_focused(dir, self.config.resize_step),
@@ -410,6 +407,9 @@ impl DriftWm {
                         // window, and a fit or fill exit can be settling too; the
                         // shared placement re-aims what that exit still owes.
                         self.map_window_to_rule_point(&window, rx, ry, true);
+                        // The new canvas position is durable — persist the move
+                        // on the session-store debounce, like the stand-in arm.
+                        self.session_store_mark_dirty();
                     }
                     Some(StageWindow::Suspended(s)) => {
                         // No live client — move the focused suspended stand-in in
@@ -607,11 +607,9 @@ impl DriftWm {
                 self.map_window(element.clone(), new_loc, true);
                 let serial = smithay::utils::SERIAL_COUNTER.next_serial();
                 self.raise_and_focus_element(&element, serial);
-                // A stand-in's canvas position is durable — persist the move on
-                // the session-store debounce (the client arm stays unmarked).
-                if matches!(element, StageWindow::Suspended(_)) {
-                    self.session_store_mark_dirty();
-                }
+                // The element's canvas position is durable — persist the move on
+                // the session-store debounce.
+                self.session_store_mark_dirty();
             }
             Action::SendCursorToOutput(dir) => {
                 // The cursor's output (active_output), not keyboard focus or

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -626,6 +626,9 @@ fn cmd_move(window: Option<WindowSelector>, to: Option<(i32, i32)>, state: &mut 
             // focus; a selector can reach any window.
             let activate = state.focused_window().as_ref() == Some(&window);
             state.map_window_to_rule_point(&window, x, y, activate);
+            // The new position is durable — persist it on the session-store
+            // debounce, matching the stand-in arm above.
+            state.session_store_mark_dirty();
             Ok(Response::Position { x, y })
         }
     }

--- a/src/state/resize.rs
+++ b/src/state/resize.rs
@@ -69,7 +69,7 @@ impl PendingResize {
     /// rounded answer as the client sizing itself instead would re-derive every
     /// repeated request from the rounded size and walk every cell-snapping
     /// terminal by half its rounding per call.
-    fn is_live(&self, window: &Window) -> bool {
+    pub(crate) fn is_live(&self, window: &Window) -> bool {
         let committed = window.geometry().size;
         let between = |c: i32, a: i32, b: i32| c >= a.min(b) && c <= a.max(b);
         super::configured_window_size(window) == self.requested

--- a/src/state/session_store.rs
+++ b/src/state/session_store.rs
@@ -2,11 +2,16 @@
 //! an envelope from live state, write it through the [`driftwm::session`] IO,
 //! and materialize it back into suspended windows at startup.
 //!
-//! Cadence: a create or dismiss writes immediately; a move or resize arms a
-//! short debounce timer; graceful shutdown fsync's a final write. Suspended
-//! windows are saved regardless of `restore_windows`; a live window is saved as
-//! a `Quit` record when that flag resolves on for it (global default or a
-//! per-app rule). `path == None` disables everything (a
+//! Cadence: a create, dismiss, or settled move/resize arms a short debounce
+//! timer that writes live and suspended windows together; graceful shutdown
+//! fsync's a final write. Writing live windows at steady state (not just at
+//! shutdown) keeps the file current across a crash or SIGKILL, and makes the
+//! shutdown write a last safety net instead of the sole source of truth —
+//! otherwise a logout that dispatches client teardown before the final
+//! serialize records an empty session (the windows were already unmapped).
+//! Suspended windows are saved regardless of `restore_windows`; a live window
+//! is saved as a `Quit` record when that flag resolves on for it (global
+//! default or a per-app rule). `path == None` disables everything (a
 //! winit dev session without `--session-file`, or a fixture without an
 //! injected path).
 
@@ -300,11 +305,12 @@ impl DriftWm {
         self.write_session(true, true);
     }
 
-    /// Steady-state write: suspended windows + carried-forward + cameras, no
-    /// live windows, no fsync. Clears the dirty flag.
+    /// Steady-state write: live windows (when `restore_windows` allows),
+    /// suspended windows, carried-forward entries and cameras; no fsync.
+    /// Clears the dirty flag.
     fn session_store_flush(&mut self) {
         self.session_store.dirty = false;
-        self.write_session(false, false);
+        self.write_session(true, false);
     }
 
     fn write_session(&mut self, include_live: bool, fsync: bool) {

--- a/src/tests/session_restore.rs
+++ b/src/tests/session_restore.rs
@@ -1201,11 +1201,11 @@ fn steady_state_flush_writes_live_windows() {
     let saved = session::read(&path);
     assert_eq!(saved.entries.len(), 2);
     assert_eq!(saved.entries[0].app_id, "alpha");
-    assert_eq!(saved.entries[0].position, [700, -662]);
-    assert_eq!(saved.entries[0].size, [400, 275]);
+    assert_eq!(saved.entries[0].position, [700, -650]);
+    assert_eq!(saved.entries[0].size, [400, 300]);
     assert_eq!(saved.entries[1].app_id, "beta");
-    assert_eq!(saved.entries[1].position, [-200, -212]);
-    assert_eq!(saved.entries[1].size, [200, 175]);
+    assert_eq!(saved.entries[1].position, [-200, -200]);
+    assert_eq!(saved.entries[1].size, [200, 200]);
     assert!(saved.entries.iter().all(|e| e.origin == Origin::Quit));
 
     // The flush is a true steady-state write: the file loads back into a fresh
@@ -1253,7 +1253,54 @@ fn closing_a_live_window_drops_it_from_the_steady_state_file() {
     let saved = session::read(&path);
     assert_eq!(saved.entries.len(), 1);
     assert_eq!(saved.entries[0].app_id, "alpha");
-    assert_eq!(saved.entries[0].position, [700, -662]);
+    assert_eq!(saved.entries[0].position, [700, -650]);
+}
+
+/// The IPC `resize` verb (and the grow/shrink steps behind it) settles on the
+/// client's answering commit, which arms the session-store debounce like a grab
+/// resize's settle does — a crash after `msg resize` restores the new size, not
+/// the pre-resize one.
+#[test]
+fn ipc_resize_of_a_live_window_persists_at_steady_state() {
+    let cache = TempDir::new();
+    let tmp = TempDir::new();
+    let path = tmp.path().join("session.json");
+
+    let mut f = Fixture::with_config(config_restore(true));
+    f.add_output(1, (1920, 1080));
+    inject_cache(&mut f, &cache, &["alpha"]);
+    f.state().session_store.path = Some(path.clone());
+
+    let id = f.add_client();
+    let surface = map_at(&mut f, id, "alpha", (400, 300), (500, 500));
+    f.state().session_store_write_now();
+    assert_eq!(session::read(&path).entries[0].size, [400, 300]);
+
+    assert_eq!(
+        crate::ipc::dispatch(
+            crate::ipc::protocol::Request::Resize {
+                window: None,
+                to: Some((600, 500)),
+            },
+            f.state(),
+        ),
+        Ok(crate::ipc::protocol::Response::Size {
+            width: 600,
+            height: 500,
+        })
+    );
+    // Deliver the configure the request queued before adopting it, or the
+    // client takes the stale map-time configure (an empty size) for the new one.
+    f.roundtrip(id);
+    super::adopt_last_configure(&mut f, id, &surface);
+    f.dispatch();
+
+    // The answering commit armed the debounce; flush straight through and the
+    // new size is what a crash would restore.
+    f.state().session_store_write_now();
+    let saved = session::read(&path);
+    assert_eq!(saved.entries.len(), 1);
+    assert_eq!(saved.entries[0].size, [600, 500]);
 }
 
 /// The `csd` flag round-trips through session.json: a CSD window suspends to a

--- a/src/tests/session_restore.rs
+++ b/src/tests/session_restore.rs
@@ -1,6 +1,9 @@
 //! Durable session store + restore: the quit-serialize round-trip, origin
 //! filtering with carry-forward when `restore_windows` is off, fresh-boot camera
-//! seeding, and the immediate write on create/dismiss. The fixture drives the
+//! seeding, and the immediate write on create/dismiss. The steady-state flush —
+//! the debounced write a create/close/move/resize arms — records live windows
+//! too, so a crash (or a logout that dispatches client teardown before the final
+//! serialize) leaves the current canvas in the file. The fixture drives the
 //! same `serialize_session_on_shutdown` the main.rs choke point calls; the
 //! post-`run()` wiring itself (Quit + signalfd both reaching it) is hardware
 //! smoke, not covered here.
@@ -1167,6 +1170,90 @@ fn create_and_dismiss_write_immediately() {
         after_dismiss.entries.is_empty(),
         "dismiss wrote through at once"
     );
+}
+
+/// A steady-state flush records live windows, not just suspended stand-ins:
+/// the crash-recovery contract. A SIGKILL — or a logout that dispatches client
+/// teardown before the shutdown serialize — lands with the current canvas in
+/// the file instead of an empty rewrite that erases the prior session. The
+/// fixture has no timer loop, so drive the debounce through the immediate-write
+/// entry, which runs the same flush.
+#[test]
+fn steady_state_flush_writes_live_windows() {
+    let cache = TempDir::new();
+    let tmp = TempDir::new();
+    let path = tmp.path().join("session.json");
+
+    let mut f = Fixture::with_config(config_restore(true));
+    f.add_output(1, (1920, 1080));
+    inject_cache(&mut f, &cache, &["alpha", "beta"]);
+    f.state().session_store.path = Some(path.clone());
+
+    let a = f.add_client();
+    map_at(&mut f, a, "alpha", (400, 300), (500, 500));
+    let b = f.add_client();
+    map_at(&mut f, b, "beta", (200, 200), (-300, 100));
+
+    f.state().session_store_write_now();
+
+    // Both live windows, in z-order, as quit records at their shrunken-body
+    // rects — the same entries the shutdown serialize writes.
+    let saved = session::read(&path);
+    assert_eq!(saved.entries.len(), 2);
+    assert_eq!(saved.entries[0].app_id, "alpha");
+    assert_eq!(saved.entries[0].position, [700, -662]);
+    assert_eq!(saved.entries[0].size, [400, 275]);
+    assert_eq!(saved.entries[1].app_id, "beta");
+    assert_eq!(saved.entries[1].position, [-200, -212]);
+    assert_eq!(saved.entries[1].size, [200, 175]);
+    assert!(saved.entries.iter().all(|e| e.origin == Origin::Quit));
+
+    // The flush is a true steady-state write: the file loads back into a fresh
+    // compositor, so a crash mid-session recovers the canvas.
+    let mut f = Fixture::with_config(config_restore(true));
+    f.add_output(1, (1920, 1080));
+    f.state().session_store.path = Some(path.clone());
+    f.state().load_session();
+    let restored = suspended_in_order(&mut f);
+    assert_eq!(restored.len(), 2);
+    assert_eq!(restored[0].0.identity.app_id, "alpha");
+    assert_eq!(restored[0].1, Point::from((500, 525)));
+    for (s, _) in restored {
+        f.state().dismiss_suspended(s.id);
+    }
+}
+
+/// Closing a live window drops it from the steady-state file: the teardown
+/// arms the same debounce as a create, so a crash after a manual close cannot
+/// resurrect a window the user already dismissed.
+#[test]
+fn closing_a_live_window_drops_it_from_the_steady_state_file() {
+    let cache = TempDir::new();
+    let tmp = TempDir::new();
+    let path = tmp.path().join("session.json");
+
+    let mut f = Fixture::with_config(config_restore(true));
+    f.add_output(1, (1920, 1080));
+    inject_cache(&mut f, &cache, &["alpha", "beta"]);
+    f.state().session_store.path = Some(path.clone());
+
+    let a = f.add_client();
+    map_at(&mut f, a, "alpha", (400, 300), (500, 500));
+    let b = f.add_client();
+    let b_surface = map_at(&mut f, b, "beta", (200, 200), (-300, 100));
+    f.state().session_store_write_now();
+    assert_eq!(session::read(&path).entries.len(), 2);
+
+    // The user closes beta; the client teardown unmaps it and arms the debounce.
+    f.client(b).window(&b_surface).destroy();
+    f.roundtrip(b);
+    f.dispatch();
+    f.state().session_store_write_now();
+
+    let saved = session::read(&path);
+    assert_eq!(saved.entries.len(), 1);
+    assert_eq!(saved.entries[0].app_id, "alpha");
+    assert_eq!(saved.entries[0].position, [700, -662]);
 }
 
 /// The `csd` flag round-trips through session.json: a CSD window suspends to a

--- a/src/tests/stand_in_parity.rs
+++ b/src/tests/stand_in_parity.rs
@@ -587,11 +587,12 @@ fn nudge_moves_client_and_stand_in_alike() {
     }
 }
 
-/// A stand-in's canvas position is durable session state, so nudging one arms
-/// the debounced write — while nudging a client window, whose position the
-/// durable store doesn't own, leaves it unarmed.
+/// A nudge moves an element on the canvas, and both a live window's and a
+/// stand-in's canvas position are durable session state — the steady-state
+/// flush records live windows — so nudging either one arms the debounced
+/// write.
 #[test]
-fn nudge_marks_the_session_store_dirty_only_for_a_stand_in() {
+fn nudge_marks_the_session_store_dirty_for_live_and_stand_in() {
     let tmp = TempDir::new();
     let mut f = Fixture::new();
     f.add_output(1, (1920, 1080));
@@ -618,8 +619,9 @@ fn nudge_marks_the_session_store_dirty_only_for_a_stand_in() {
         "precondition: the client nudge ran"
     );
     assert!(
-        !f.state().session_store_dirty(),
-        "a client window's nudge is not durable session state"
+        f.state().session_store_dirty(),
+        "a live window's nudge is durable session state — the flush records \
+         live windows, so a crash restores the nudged position"
     );
 
     let sid = f.state().insert_suspended_for_test(


### PR DESCRIPTION
## Problem
On logout the compositor and its clients receive SIGTERM at the same time. The session file can end up empty (`entries: []`) so the next login restores an empty desktop even though `restore_windows = true` is set and the previous session had windows open.

## Root cause
A race at session teardown. SIGTERM arrives via signalfd, whose handler calls `LoopSignal::stop()`. But calloop only checks the stop flag after dispatching the entire batch of events ready in the current poll iteration. The client-disconnect events (wayland socket data) sit in that same batch, and when they dispatch first they walk `toplevel_destroyed` -> `unmap_window` -> `stage.remove`, before the loop stops. `serialize_session_on_shutdown()` then runs against an already-drained stage and overwrites the previous good save with an empty entries list.

## Fix
Make the durable file reflect the live session continuously, so no single shutdown-time write is the source of truth:
1. Steady-state flush now records live windows. `session_store_flush()` writes with `include_live = true`, so the 1s debounced write persists live windows (as `Quit` records, subject to the same `restore_windows` resolution and widget/dialog filters as the shutdown write) alongside suspended stand-ins, carried-forward entries, cameras and bookmarks. A crash or SIGKILL now leaves the current canvas in the file.
2. Arm the debounce from every durable live mutation: window create (`new_toplevel`), window close (`toplevel_destroyed`), end of a move grab, end of a resize grab, the commit-time resize reposition (`handle_resize_commit`), and msg move.
3. The shutdown serialize stays as the final fsync'd stroke - unchanged behavior for graceful exits.

## Note
The count-matched carried-quit dedup now also applies at flush time (not only at shutdown). With `restore_windows` on, a carried record is dropped once its app relaunches live, and a window the user closes manually leaves the file - previously a carried record survived a manual close until the next graceful shutdown and resurrected the window. This matches the documented contract (manually closed windows are not restored).

## Rebase
After rebasing on updated main, re-checked the new code against the same contract:
- The new `msg resize` verb and grow/shrink actions never arm `ResizeState` - they write a `PendingResize` + plain sized configure - so their answering commit fell through the grab-path settle in `handle_resize_commit`. Now the Idle branch marks the session dirty when a live `PendingResize` answers.
- Nudge, go-to-bookmark, move-to-bookmark and send-to-output marked the store dirty only for stand-ins; live-window arms now mark too.
- Session tests updated to the frame-space file convention (commits [f87a352](https://github.com/malbiruk/driftwm/commit/f87a3520402e6aabf8c50022f1b855e78453fd2f) moved entries to visual-frame rects).