### PR TITLE
Fix VRAM exhaustion with the monitor off: skip placeholder outputs in the idle frame-callback fallback

### DIFF
--- a/src/render/lifecycle.rs
+++ b/src/render/lifecycle.rs
@@ -364,7 +364,16 @@ pub fn post_render(state: &mut crate::state::DriftWm, output: &Output) {
 /// doesn't gate them.
 pub fn send_frame_callbacks_fallback(state: &mut crate::state::DriftWm) {
     let time = state.start_time.elapsed();
-    let outputs: Vec<Output> = state.space.outputs().cloned().collect();
+    // Skip the virtual placeholders a full disconnect leaves behind: they have
+    // no DRM surface, so nothing composites and nothing releases the buffers a
+    // serviced client draws into. With every output a placeholder this leaves
+    // no output at all and the heartbeat goes quiet, which is the point.
+    let outputs: Vec<Output> = state
+        .space
+        .outputs()
+        .filter(|o| !state.disconnected_outputs.contains(&o.name()))
+        .cloned()
+        .collect();
 
     // Skip blanked outputs, matching the udev render loop's own skip: a layer
     // commit marks its output dirty unconditionally (unlike a window's), so

--- a/src/tests/layer_frame_gating.rs
+++ b/src/tests/layer_frame_gating.rs
@@ -411,6 +411,51 @@ fn idle_fallback_skips_a_dpms_off_output() {
     );
 }
 
+/// Unplugging the last output leaves only a virtual placeholder, which has no
+/// DRM surface: nothing composites, so nothing ever releases what clients draw.
+/// Servicing the heartbeat against it makes every client redraw once a second
+/// into buffers that accumulate until VRAM is exhausted and the driver spills
+/// to system memory.
+#[test]
+fn idle_fallback_goes_silent_while_only_placeholders_remain() {
+    let mut f = Fixture::new();
+    let output = f.add_output(1, (1920, 1080));
+    let id = f.add_client();
+    let bar = map_layer(&mut f, id, None, zwlr_layer_shell_v1::Layer::Top, "bar");
+    let window = map_window(&mut f, id, "app", (400, 300));
+
+    crate::render::post_render(f.state(), &output); // warm-up
+
+    f.remove_output(&output);
+    assert!(f.state().disconnected_outputs.contains("HEADLESS-1"));
+
+    let bar_frame = request_frame(&mut f, id, &bar);
+    let window_frame = request_frame(&mut f, id, &window);
+    f.state().start_time -= Duration::from_millis(1000);
+    crate::render::send_frame_callbacks_fallback(f.state());
+    f.roundtrip(id);
+
+    assert!(
+        !delivered(&bar_frame),
+        "a layer surface on a placeholder output must not be serviced"
+    );
+    assert!(
+        !delivered(&window_frame),
+        "a window must not be driven to redraw while no output can composite it"
+    );
+
+    // Reconnecting retires the placeholder, and the heartbeat comes back.
+    f.add_output(2, (1920, 1080));
+    f.state().start_time -= Duration::from_millis(1000);
+    crate::render::send_frame_callbacks_fallback(f.state());
+    f.roundtrip(id);
+
+    assert!(
+        delivered(&window_frame),
+        "a live output must resume servicing the heartbeat"
+    );
+}
+
 /// Regression guard for the toplevel loop in `post_render`: windows still gate
 /// purely on canvas-visibility, not on the lock/fullscreen cull predicates.
 #[test]


### PR DESCRIPTION
Unplugging the last output keeps a virtual placeholder so `active_output()` stays `Some`, but the placeholder has no DRM surface. `send_frame_callbacks_fallback` filtered only `dpms_off_outputs`, so the idle heartbeat kept servicing that placeholder: every client redrew once a second into buffers nothing composited and nothing released. On DisplayPort this fires on an ordinary overnight screen-off, since powering the monitor off drops the link and reads as a real disconnect rather than DPMS-off.

- filter `disconnected_outputs` out of the fallback's output list, the same predicate `refresh_foreign_toplevels` and `refresh_ext_workspaces` already use in this file. With every output a placeholder the list is empty and the heartbeat goes quiet
- regression test asserts silence for both a layer surface and a window while only placeholders remain, and that reconnecting restores the heartbeat

Measured on a 3070, 3440x1440 DP-1, nvidia-open 610.57.04: the compositor grew 278 MiB to 6483 MiB in 32 minutes with the monitor off, filled all 8 GiB of VRAM, then spilled to system memory overnight until 48 GiB of RAM ran out and the session died. Three mornings in a row ended in "No Signal" and a forced power cycle.

After the fix, a 67-hour screen-off: 259 MiB to 427 MiB total, peak VRAM 985 MiB of 8192, zero sysmem spill events across ~1750 samples. The remaining growth is a separate, self-correcting path (a shell's layer surfaces commit on their own timer, and a layer commit marks its output dirty unconditionally) and it is fully reclaimed on reconnect: 427 MiB dropped back to 142 MiB in a single sample when the monitor came back.

The test was written first and confirmed failing on unmodified `main` before the fix. `cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test -- --include-ignored --skip soak` all pass.
