### PR TITLE
fix wlr-randr rotation touchscreen bug

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -789,8 +789,10 @@ impl DriftWm {
             return;
         };
 
-        // position_transformed gives screen-local coords (0..width, 0..height)
-        let screen_pos = event.position_transformed(output_geo.size);
+        let transform = output.current_transform();
+        let size = transform.invert().transform_size(output_geo.size);
+        let screen_pos =
+            transform.transform_point_in(event.position_transformed(size), &size.to_f64());
 
         // When locked, pointer only targets the lock surface
         if self.session_lock.is_locked() {

--- a/src/input/touch.rs
+++ b/src/input/touch.rs
@@ -486,7 +486,10 @@ impl DriftWm {
         self.focused_output = Some(output.clone());
         self.cursor.hidden_by_touch = true;
 
-        let screen_pos = event.position_transformed(output_geo.size);
+        let transform = output.current_transform();
+        let size = transform.invert().transform_size(output_geo.size);
+        let screen_pos =
+            transform.transform_point_in(event.position_transformed(size), &size.to_f64());
         let (camera, zoom) = {
             let os = output_state(&output);
             (os.camera, os.zoom)
@@ -841,7 +844,10 @@ impl DriftWm {
         if !self.session_lock.is_locked() || self.touch_state.lock_slots.contains(&slot) {
             self.cursor.hidden_by_touch = true;
         }
-        let screen_pos = event.position_transformed(output_geo.size);
+        let transform = output.current_transform();
+        let size = transform.invert().transform_size(output_geo.size);
+        let screen_pos =
+            transform.transform_point_in(event.position_transformed(size), &size.to_f64());
         let (camera, zoom) = {
             let os = output_state(&output);
             (os.camera, os.zoom)


### PR DESCRIPTION
Fixes an issue where touch inputs and absolute pointer events (such as digitizers) became misaligned when an output was rotated or transformed (e.g., via wlr-randr).

# Changes

- Updated absolute pointer and touch handlers in mod.rs and touch.rs to retrieve the output's current Transform.
- Calculated the unrotated coordinate space using the inverse transform, mapped the input events to it, and then applied the output transform to the resulting coordinates before passing them to the compositor.

# Testing

The complete local test suite was run inside the Nix flake development environment:
`nix develop --command cargo test -- --include-ignored --skip soak`

The change was also tested on a real device.

# AI disclousure

AI agent was used for generating this fix
