### PR TITLE
Allow dragging of widget windows via IPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ it all together. Use it as a starting point or steal pieces.
 
 ## Community
 
+- [driftwm-desktop](https://github.com/C10udburst/driftwm-desktop) - A layer for displaying `~/Desktop` contents on canvas as draggable icons.
 - [driftwm-settings](https://github.com/wwmaxik/driftwm-settings) — GTK4 GUI config editor
 - [driftwm-noctalia](https://github.com/youssefvdel/driftwm-noctalia) — noctalia shell fork adapted for driftwm
 - [Just Enough Shell](https://github.com/ORFLEM/just_enough_shell) — minimal QuickShell desktop shell, driftwm-focused

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -633,17 +633,23 @@ fn cmd_move(window: Option<WindowSelector>, to: Option<(i32, i32)>, state: &mut 
             // camera park, and one held back for a deferred adopt is about to be
             // teleported into a slot — writing the canvas position would
             // silently do nothing, displace the park, or be overwritten.
-            if !state.is_canvas_window(&window) {
+            if state.is_pinned(&window)
+                || state.is_window_fullscreen(&window)
+                || state.hidden_by_deferred_adopt(&window)
+            {
                 return Err(
-                    "this window has no canvas position to move: it is pinned, fullscreen, a \
-                     widget, or not on screen yet"
+                    "this window has no canvas position to move: it is pinned, fullscreen, or \
+                     not on screen yet"
                         .into(),
                 );
             }
             // Activating is only consistent when the target already holds
-            // focus; a selector can reach any window.
-            let activate = state.focused_window().as_ref() == Some(&window);
+            // focus; a selector can reach any window. Widgets never activate.
+            let activate = state.focused_window().as_ref() == Some(&window) && !window.is_widget();
             state.map_window_to_rule_point(&window, x, y, activate);
+            if window.is_widget() {
+                state.enforce_below_windows();
+            }
             // The new position is durable — persist it on the session-store
             // debounce, matching the stand-in arm above.
             state.session_store_mark_dirty();

--- a/src/tests/frame_space.rs
+++ b/src/tests/frame_space.rs
@@ -334,3 +334,78 @@ fn move_to_bookmark_and_msg_move_agree_for_a_stand_in() {
 
     f.state().dismiss_suspended(sid);
 }
+
+/// A widget cannot be moved manually (no titlebar drag, gesture, or nudge),
+/// but can be moved via IPC `msg move --id <ID> <X> <Y>`.
+#[test]
+fn widget_can_be_moved_by_ipc_but_not_manually() {
+    let mut f = Fixture::with_config(config(
+        r#"
+[[window_rules]]
+app_id = "widget"
+widget = true
+
+[[window_rules]]
+app_id = "normal"
+"#,
+    ));
+    f.add_output(1, (1920, 1080));
+    origin_view(&mut f);
+    let id = f.add_client();
+
+    map_window(&mut f, id, "normal", (400, 300));
+    let normal = window_by_app_id(&mut f, "normal").unwrap();
+
+    map_window(&mut f, id, "widget", (200, 100));
+    let widget = window_by_app_id(&mut f, "widget").unwrap();
+
+    let widget_id = f.state().stage.id_of(&widget).unwrap().0;
+
+    // Precondition: manual moves decline the widget.
+    let widget_loc = f.state().stage.position_of(&widget).unwrap();
+    let center = Point::from((widget_loc.x as f64 + 100.0, widget_loc.y as f64 + 50.0));
+    assert!(
+        f.state().draggable_element_under(center).is_none(),
+        "draggable_element_under declines widgets"
+    );
+    assert!(
+        !f.state().try_start_gesture_move(center, false),
+        "gesture move declines widgets"
+    );
+
+    // IPC move by ID repositions the widget to (500, -250).
+    assert_eq!(
+        mv(
+            &mut f,
+            Some(WindowSelector::Id(widget_id)),
+            Some((500, -250))
+        ),
+        Ok(Response::Position { x: 500, y: -250 })
+    );
+
+    // Querying the position via IPC matches what was written.
+    assert_eq!(
+        mv(&mut f, Some(WindowSelector::Id(widget_id)), None),
+        Ok(Response::Position { x: 500, y: -250 })
+    );
+
+    // Widgets must remain below normal windows in stacking.
+    let entries: Vec<_> = f
+        .state()
+        .stage
+        .entries()
+        .map(|e| e.window.clone())
+        .collect();
+    let widget_idx = entries
+        .iter()
+        .position(|w| w == &StageWindow::Client(widget.clone()))
+        .unwrap();
+    let normal_idx = entries
+        .iter()
+        .position(|w| w == &StageWindow::Client(normal.clone()))
+        .unwrap();
+    assert!(
+        widget_idx < normal_idx,
+        "widget must remain stacked below normal windows"
+    );
+}


### PR DESCRIPTION
## Description

This PR addresses the ideas discussed in #204 regarding a desktop icon layer on the infinite canvas. As suggested, a full desktop icon implementation can live as an external client, but it required a minor tweak to `driftwm`'s core IPC capabilities to support dragging/moving widget windows at runtime.

### Changes
* **IPC Window Movement Enhancement:** Modified the `driftwm msg move` behavior. Previously, it was impossible to move widget windows via this command. Now, widget windows can be moved dynamically at runtime, but **strictly via IPC**.
* **Documentation / Community:** Added my external companion project [driftwm-desktop](https://github.com/C10udburst/driftwm-desktop) to the Community section of the `README.md`.

## Related Issues & Discussions
* Closes / Resolves / Mentions https://github.com/malbiruk/driftwm/discussions/204

## How Has This Been Tested?
* Added a test and run the whole test suite to confirm no breaking changes
* Tested with the `driftwm-desktop` client to confirm that individual icon widget windows (configured with `widget = true`) can now be dragged, scattered, and successfully repositioned across the infinite canvas via IPC messages without breaking their focus or canvas-binding behaviors.
